### PR TITLE
[fix] Dockerfile build `apt update` failing when running in Docker < 20.10.9

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -19,6 +19,10 @@ COPY --from=builder /src/dist/calls-recorder-linux-amd64 /opt/calls-recorder/bin
 # Setup system dependencies
 WORKDIR /workdir
 
+# Workaround for Ubuntu 22.04 `apt update` failing when running under Docker < 20.10.9
+# https://stackoverflow.com/questions/71941032/why-i-cannot-run-apt-update-inside-a-fresh-ubuntu22-04
+RUN sed -i -e 's/^APT/# APT/' -e 's/^DPkg/# DPkg/' /etc/apt/apt.conf.d/docker-clean
+
 ARG DEBIAN_FRONTEND=noninteractive
 RUN set -ex && \
     apt-get update && \


### PR DESCRIPTION

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This is a Workaround for Ubuntu 22.04 `apt update` failing when building under Docker < 20.10.9 

TLDR: Ubuntu 22.04 uses an unsupported SystemCall named `clone3` by Glibc >= 2.34, when running `apt-get update` / `apt update`

This causes the build to fail with:
```bash
E: Problem executing scripts APT::Update::Post-Invoke 'rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true'
E: Sub-process returned an error code
The command '/bin/bash -c set -ex &&     apt-get update &&     apt-get install --no-install-recommends -y ffmpeg=7:4.4.2-0ubuntu0.22.04.1 pulseaudio=1:15.99.1+dfsg1-1ubuntu2       xvfb=2:21.1.3-2ubuntu2.3 wget=1.21.2-2ubuntu1 unzip=6.0-26ubuntu3.1 fonts-emojione=2.2.6+16.10.20160804-0ubuntu2 ca-certificates=20211016 &&     wget --progress=dot:giga https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb &&     apt-get update &&     apt-get install --no-install-recommends -y ./google-chrome-stable_current_amd64.deb &&     wget --progress=dot:giga -N http://chromedriver.storage.googleapis.com/2.46/chromedriver_linux64.zip &&     unzip chromedriver_linux64.zip &&     chmod +x chromedriver &&     mv -f chromedriver /usr/local/bin/chromedriver &&     rm chromedriver_linux64.zip &&     rm google-chrome-stable_current_amd64.deb &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     adduser root pulse-access &&     mkdir -pv ~/.cache/xdgr' returned a non-zero code: 100
07:14:10 [FAIL]
make: *** [Makefile:145: docker-build] Error 1
```
https://git.internal.mattermost.com/mattermost/ci-only/calls-recorder/-/jobs/1215239

Fixed in Docker >= 20.10.9 
Since the internal Build system running Docker < 20.10.9  is affected, we opt to introduce this workaround as a low hanging fruit, before updating the build system dockerd to Docker >= 20.10.9 which contains the fix. 


Reference: 
https://stackoverflow.com/questions/71941032/why-i-cannot-run-apt-update-inside-a-fresh-ubuntu22-04

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
**Ticket:** https://mattermost.atlassian.net/browse/CLD-4589
