### PR TITLE
[MM-48946] Mitigate read after write issue preventing upload

### DIFF
--- a/cmd/recorder/upload.go
+++ b/cmd/recorder/upload.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 )
@@ -46,6 +47,9 @@ func (rec *Recorder) uploadRecording() error {
 	if err := json.NewDecoder(resp.Body).Decode(&us); err != nil {
 		return fmt.Errorf("failed to decode response body: %w", err)
 	}
+
+	// Bad hack to prevent read after write issue (MM-48946)
+	time.Sleep(2 * time.Second)
 
 	resp, err = client.DoAPIRequestReader(http.MethodPost, apiURL+"/uploads/"+us.Id, file, nil)
 	defer resp.Body.Close()


### PR DESCRIPTION
#### Summary

There's a read-after-write issue with uploading files. 

1. [Upload session gets created and returned to client](https://github.com/mattermost/calls-recorder/blob/9abe12e6c924f94f36c0b0214ef07fa3fe8fba0f/cmd/recorder/upload.go#L40-L44)
2. [Client attempts to upload for the created session](https://github.com/mattermost/calls-recorder/blob/9abe12e6c924f94f36c0b0214ef07fa3fe8fba0f/cmd/recorder/upload.go#L50-L54)
3. [Plugin attempts to fetch the session the client wants to upload for](https://github.com/mattermost/mattermost-plugin-calls/blob/f0f70606c4142de27ee456aff2e2abb983a30fe9/server/bot_api.go#L66)
4. Server returns not found as the Get operation is done [on read replicas](https://github.com/mattermost/mattermost-server/blob/7606fd9725eb37e4546d9c1bd9325866b757dbd9/store/sqlstore/upload_session_store.go#L94) which may have not updated yet. 

This requires proper fixing at both plugin and server levels so opting for a quick hack to move things forward now.

I also added a very brutal retry logic in case of other failures.

Finally I fixed a bug as the recording file should only be deleted if everything succeeded otherwise we could be losing data (and we were in this case).

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-48946
