### PR TITLE
[MM-49635] Store bot token in fragment

### DIFF
--- a/cmd/recorder/recorder.go
+++ b/cmd/recorder/recorder.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -209,8 +210,15 @@ func (rec *Recorder) Start() error {
 		return fmt.Errorf("failed to run display server: %s", err)
 	}
 
-	recURL := fmt.Sprintf("%s/plugins/%s/standalone/recording.html?call_id=%s&token=%s",
-		rec.cfg.SiteURL, pluginID, rec.cfg.CallID, rec.cfg.AuthToken)
+	data, err := json.Marshal(map[string]string{
+		"token": rec.cfg.AuthToken,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal data: %s", err)
+	}
+
+	recURL := fmt.Sprintf("%s/plugins/%s/standalone/recording.html?call_id=%s#%s",
+		rec.cfg.SiteURL, pluginID, rec.cfg.CallID, base64.URLEncoding.EncodeToString(data))
 
 	go func() {
 		if err := rec.runBrowser(recURL); err != nil {


### PR DESCRIPTION
#### Summary

PR moves away from storing the bot token in query and moves it to the fragment portion.

#### Related PR

https://github.com/mattermost/mattermost-plugin-calls/pull/296

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49635