### PR TITLE
[MM-49667] Enable sandboxing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -352,6 +352,10 @@ else
 endif
 	@$(OK) Generating github-release http://github.com/$(GITHUB_ORG)/$(GITHUB_REPO)/releases/tag/$(APP_VERSION) ...
 
+.PHONY: go-pinned-packages
+go-pinned-packages: ## to update pinned packages list for the Ubuntu based Docker image
+	go run ./build/generator.go
+
 .PHONY: clean
 clean: ## to clean-up
 	@$(INFO) cleaning /${GO_OUT_BIN_DIR} folder...

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,6 +2,48 @@
 # A multi stage build, with golang used as a builder
 # and ubuntu:22.04 as runner
 ARG GO_IMAGE=golang:1.18@sha256:fa71e1447cb0241324162a6c51297206928d755b16142eceec7b809af55061e5
+
+FROM ubuntu:22.04@sha256:817cfe4672284dcbfee885b1a66094fd907630d610cab329114d036716be49ba as base
+
+# Setup system dependencies
+WORKDIR /workdir
+
+# Workaround for Ubuntu 22.04 `apt update` failing when running under Docker < 20.10.9
+# https://stackoverflow.com/questions/71941032/why-i-cannot-run-apt-update-inside-a-fresh-ubuntu22-04
+RUN sed -i -e 's/^APT/# APT/' -e 's/^DPkg/# DPkg/' /etc/apt/apt.conf.d/docker-clean
+
+ARG CHROMIUM_VERSION=109.0.5414.74-0
+ARG DEBIAN_FRONTEND=noninteractive
+RUN set -ex && \
+    apt-get update && \
+    apt-get install --no-install-recommends -y \
+      ffmpeg=7:4.4.2-0ubuntu0.22.04.1 \
+      pulseaudio=1:15.99.1+dfsg1-1ubuntu2 \
+      xvfb=2:21.1.3* wget=1.21.2-2ubuntu1 \
+      unzip=6.0-26ubuntu3.1 \
+      fonts-emojione=2.2.6+16.10.20160804-0ubuntu2 \
+      ca-certificates=20211016 && \
+    apt-get update && \
+    wget --progress=dot:giga -N \
+      -O chromium-chromedriver.deb \
+      https://launchpad.net/~savoury1/+archive/ubuntu/chromium/+files/chromium-chromedriver_${CHROMIUM_VERSION}ubuntu0.22.04.1sav1_amd64.deb  && \
+    wget --progress=dot:giga -N \
+      -O chromium-codecs-ffmpeg-extra.deb \
+      https://launchpad.net/~savoury1/+archive/ubuntu/chromium/+files/chromium-codecs-ffmpeg-extra_${CHROMIUM_VERSION}ubuntu0.22.04.1sav1_amd64.deb && \
+    wget --progress=dot:giga -N \
+      -O chromium-browser.deb \
+      https://launchpad.net/~savoury1/+archive/ubuntu/chromium/+files/chromium-browser_${CHROMIUM_VERSION}ubuntu0.22.04.1sav1_amd64.deb && \
+    apt-get install --no-install-recommends -y ./chromium-chromedriver.deb \
+    ./chromium-codecs-ffmpeg-extra.deb \
+    ./chromium-browser.deb && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    adduser root pulse-access && \
+    mkdir -pv ~/.cache/xdgr
+
+# Create unprivileged user to run the recorder process
+RUN groupadd -r calls && useradd -mr -g calls -G audio,video,pulse-access calls
+
 # hadolint ignore=DL3006
 FROM ${GO_IMAGE} as builder
 
@@ -13,32 +55,8 @@ COPY . /src
 WORKDIR /src
 RUN make go-build
 
-FROM ubuntu:22.04@sha256:817cfe4672284dcbfee885b1a66094fd907630d610cab329114d036716be49ba as runner
+FROM base AS runner
 COPY --from=builder /src/dist/calls-recorder-linux-amd64 /opt/calls-recorder/bin/calls-recorder
-
-# Setup system dependencies
-WORKDIR /workdir
-
-# Workaround for Ubuntu 22.04 `apt update` failing when running under Docker < 20.10.9
-# https://stackoverflow.com/questions/71941032/why-i-cannot-run-apt-update-inside-a-fresh-ubuntu22-04
-RUN sed -i -e 's/^APT/# APT/' -e 's/^DPkg/# DPkg/' /etc/apt/apt.conf.d/docker-clean
-
-ARG DEBIAN_FRONTEND=noninteractive
-RUN set -ex && \
-    apt-get update && \
-    apt-get install --no-install-recommends -y ffmpeg=7:4.4.2-0ubuntu0.22.04.1 pulseaudio=1:15.99.1+dfsg1-1ubuntu2 \
-      xvfb=2:21.1.3-2ubuntu2.3 wget=1.21.2-2ubuntu1 unzip=6.0-26ubuntu3.1 fonts-emojione=2.2.6+16.10.20160804-0ubuntu2 ca-certificates=20211016 && \
-    apt-get update && \
-    wget --progress=dot:giga -N https://launchpad.net/~savoury1/+archive/ubuntu/chromium/+files/chromium-chromedriver_107.0.5304.121-0ubuntu0.22.04.1sav0_amd64.deb && \
-    wget --progress=dot:giga -N https://launchpad.net/~savoury1/+archive/ubuntu/chromium/+files/chromium-codecs-ffmpeg-extra_107.0.5304.121-0ubuntu0.22.04.1sav0_amd64.deb && \
-    wget --progress=dot:giga -N https://launchpad.net/~savoury1/+archive/ubuntu/chromium/+files/chromium-browser_107.0.5304.121-0ubuntu0.22.04.1sav0_amd64.deb && \
-    apt-get install --no-install-recommends -y ./chromium-chromedriver_107.0.5304.121-0ubuntu0.22.04.1sav0_amd64.deb \
-    ./chromium-codecs-ffmpeg-extra_107.0.5304.121-0ubuntu0.22.04.1sav0_amd64.deb \
-    ./chromium-browser_107.0.5304.121-0ubuntu0.22.04.1sav0_amd64.deb && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    adduser root pulse-access && \
-    mkdir -pv ~/.cache/xdgr
 
 # copy binary
 COPY ./build/entrypoint.sh .

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,15 +14,11 @@ RUN sed -i -e 's/^APT/# APT/' -e 's/^DPkg/# DPkg/' /etc/apt/apt.conf.d/docker-cl
 
 ARG CHROMIUM_VERSION=109.0.5414.74-0
 ARG DEBIAN_FRONTEND=noninteractive
+COPY ./build/pkgs_list .
+# hadolint ignore=DL3008,SC2046
 RUN set -ex && \
     apt-get update && \
-    apt-get install --no-install-recommends -y \
-      ffmpeg=7:4.4.2-0ubuntu0.22.04.1 \
-      pulseaudio=1:15.99.1+dfsg1-1ubuntu2 \
-      xvfb=2:21.1.3* wget=1.21.2-2ubuntu1 \
-      unzip=6.0-26ubuntu3.1 \
-      fonts-emojione=2.2.6+16.10.20160804-0ubuntu2 \
-      ca-certificates=20211016 && \
+    apt-get install --no-install-recommends -y $(cat pkgs_list) && \
     apt-get update && \
     wget --progress=dot:giga -N \
       -O chromium-chromedriver.deb \

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -11,13 +11,15 @@ pulseaudio -D --verbose --exit-idle-time=-1 --system --disallow-exit
 pactl load-module module-null-sink sink_name="grab" sink_properties=device.description="monitorOUT"
 
 # Forward signals to service
-pid=0
+RECORDER_PID=0
+RECORDER_PID_FILE=/tmp/recorder.pid
 
-# SIGTERM-handler
+# SIGTERM handler
 term_handler() {
-  if [ $pid -ne 0 ]; then
-    kill -SIGTERM "$pid"
-    wait "$pid"
+  RECORDER_PID=`cat $RECORDER_PID_FILE`
+  if [ $RECORDER_PID -ne 0 ]; then
+    kill -SIGTERM "$RECORDER_PID"
+    tail --pid="$RECORDER_PID" -f /dev/null
   fi
   exit 143; # 128 + 15 -- SIGTERM
 }
@@ -25,9 +27,23 @@ term_handler() {
 # On callback, kill the last background process, which is `tail -f /dev/null` and execute the specified handler
 trap 'kill ${!}; term_handler' SIGTERM
 
-# Run service
-XDG_RUNTIME_DIR=$PATH:~/.cache/xdgr /opt/calls-recorder/bin/calls-recorder &
-pid="$!"
+# DEV_MODE is optional so we need to check whether it's set before relaying it to the recorder app.
+DEV="${DEV_MODE:-false}"
+
+RECORDER_USER=calls
+
+# Give permission to write recording files.
+chown -R $RECORDER_USER:$RECORDER_USER /recs
+
+# Run service as unprivileged user.
+runuser -l $RECORDER_USER -c \
+  "SITE_URL=$SITE_URL \
+  AUTH_TOKEN=$AUTH_TOKEN \
+  CALL_ID=$CALL_ID \
+  THREAD_ID=$THREAD_ID \
+  DEV_MODE=$DEV \
+  XDG_RUNTIME_DIR=/home/$RECORDER_USER/.cache/xdgr \
+  /opt/calls-recorder/bin/calls-recorder" &
 
 # Wait forever
 wait ${!}

--- a/build/generator.go
+++ b/build/generator.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	launchpadAPIBaseURL = "https://api.launchpad.net/1.0"
+	distroName          = "ubuntu"
+	distroVersion       = "jammy"
+	distroArch          = "amd64"
+
+	pkgsListPath = "./build/pkgs_list"
+
+	requestTimeout = 5 * time.Second
+)
+
+type Package struct {
+	Name    string
+	Version string
+}
+
+func GetPublishedPackages(c *http.Client, names []string) ([]Package, error) {
+	var pkgs []Package
+
+	for _, pkgName := range names {
+		ctx, cancelFn := context.WithTimeout(context.Background(), requestTimeout)
+		defer cancelFn()
+
+		url := fmt.Sprintf("%s/%s/+archive/primary", launchpadAPIBaseURL, distroName)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("request creation: %w", err)
+		}
+
+		q := req.URL.Query()
+		q.Add("ws.op", "getPublishedBinaries")
+		q.Add("binary_name", pkgName)
+		q.Add("exact_match", "true")
+		q.Add("distro_arch_series", fmt.Sprintf("%s/%s/%s/%s", launchpadAPIBaseURL, distroName, distroVersion, distroArch))
+		q.Add("status", "Published")
+		q.Add("order_by_date", "true")
+		req.URL.RawQuery = q.Encode()
+
+		resp, err := c.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("request failed: %w", err)
+		}
+
+		respData := map[string]any{}
+		if err := json.NewDecoder(resp.Body).Decode(&respData); err != nil {
+			return nil, fmt.Errorf("failed to decode response: %w", err)
+		}
+
+		entries, ok := respData["entries"].([]any)
+		if !ok {
+			return nil, fmt.Errorf("failed to parse response")
+		}
+
+		if len(entries) == 0 {
+			break
+		}
+
+		entry, ok := entries[0].(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("failed to parse entry")
+		}
+
+		name, ok := entry["binary_package_name"].(string)
+		if !ok {
+			return nil, fmt.Errorf("failed to parse package name")
+		}
+
+		version, ok := entry["binary_package_version"].(string)
+		if !ok {
+			return nil, fmt.Errorf("failed to parse package version")
+		}
+
+		log.Printf("found %s=%s\n", name, version)
+
+		pkgs = append(pkgs, Package{Name: name, Version: version})
+	}
+
+	return pkgs, nil
+}
+
+func GenPinnedPackages(pkgsNames []string) error {
+	c := &http.Client{}
+
+	pkgs, err := GetPublishedPackages(c, pkgsNames)
+	if err != nil {
+		return fmt.Errorf("failed to get packages: %w", err)
+	}
+
+	outFile, err := os.OpenFile(pkgsListPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
+	if err != nil {
+		return fmt.Errorf("failed to open output file: %w", err)
+	}
+	defer outFile.Close()
+
+	for _, pkg := range pkgs {
+		fmt.Fprintf(outFile, "%s=%s\n", pkg.Name, pkg.Version)
+	}
+
+	return nil
+}
+
+func parsePkgsList(data string) []string {
+	var pkgs []string
+	list := strings.Split(data, "\n")
+	for _, el := range list {
+		name, _, _ := strings.Cut(el, "=")
+		pkgs = append(pkgs, name)
+	}
+	return pkgs
+}
+
+func main() {
+	data, err := os.ReadFile(pkgsListPath)
+	if err != nil {
+		log.Fatalf("failed to read packages file: %s", err)
+	}
+
+	if err := GenPinnedPackages(parsePkgsList(string(data))); err != nil {
+		log.Fatalf("failed to generate pinned packages: %s", err)
+	}
+
+	log.Printf("done")
+}

--- a/build/pkgs_list
+++ b/build/pkgs_list
@@ -1,0 +1,7 @@
+ca-certificates=20211016ubuntu0.22.04.1
+ffmpeg=7:4.4.2-0ubuntu0.22.04.1
+fonts-emojione=2.2.6+16.10.20160804-0ubuntu2
+pulseaudio=1:15.99.1+dfsg1-1ubuntu2
+unzip=6.0-26ubuntu3.1
+wget=1.21.2-2ubuntu1
+xvfb=2:21.1.3-2ubuntu2.5

--- a/cmd/recorder/main.go
+++ b/cmd/recorder/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -9,6 +10,11 @@ import (
 
 func main() {
 	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
+
+	pid := os.Getpid()
+	if err := os.WriteFile("/tmp/recorder.pid", []byte(fmt.Sprintf("%d", pid)), 0666); err != nil {
+		log.Fatalf("failed to write pid file: %s", err)
+	}
 
 	cfg, err := loadConfig()
 	if err != nil {

--- a/cmd/recorder/recorder.go
+++ b/cmd/recorder/recorder.go
@@ -44,11 +44,9 @@ func (rec *Recorder) runBrowser(recURL string) error {
 		chromedp.NoFirstRun,
 		chromedp.NoDefaultBrowserCheck,
 		chromedp.DisableGPU,
-		chromedp.NoSandbox,
 
 		// puppeteer default behavior
 		chromedp.Flag("disable-infobars", true),
-		chromedp.Flag("enable-automation", true),
 		chromedp.Flag("disable-background-networking", true),
 		chromedp.Flag("enable-features", "NetworkService,NetworkServiceInProcess"),
 		chromedp.Flag("disable-background-timer-throttling", true),


### PR DESCRIPTION
#### Summary

This took more than expected but I am quite happy with the result. A summary of the most significant changes:

1. Reworked the `Dockerfile` to do the build as last step so that all the heavy dependencies can be cached which speeds up debugging considerably and also avoids your IP address from getting rate-limited by Ubuntu servers (yes, it happened).
2. Now running the recorder process with an unprivileged user named `calls`.
3. Now running `chromium-browser` without the `--no-sandbox` option.

Before:

```
root          20  5.5  0.4 2369224 141636 ?      Sl   21:13   0:00 /usr/lib/chromium-browser/chromium-browser --enable-pinch --disable-background-networking --disable-background-timer-throttling --window-size=1920,1080 --disable-gpu --disable-dev-shm-usage --disable-features=site-per-process,TranslateUI,BlinkGenPropertyTrees --disable-renderer-backgrounding --disable-sync --safebrowsing-disable-auto-update --password-store=basic --disable-client-side-phishing-detection --disable-extensions --disable-popup-blocking --incognito --window-position=0,0 --disable-default-apps --disable-infobars --disable-hang-monitor --disable-ipc-flooding-protection --force-color-profile=srgb --no-first-run --use-fake-device-for-media-stream --no-default-browser-check --disable-backgrounding-occluded-windows --disable-breakpad --use-mock-keychain --no-sandbox --use-fake-ui-for-media-stream --autoplay-policy=no-user-gesture-required --enable-features=NetworkService,NetworkServiceInProcess --disable-prompt-on-repost --metrics-recording-only --kiosk --display=:45 --user-data-dir=/tmp/chromedp-runner332547841 --remote-debugging-port=0 about:blank
root          28  0.0  0.0  14964  2892 ?        Sl   21:13   0:00 /usr/lib/chromium-browser/chrome_crashpad_handler --monitor-self --monitor-self-annotation=ptype=crashpad-handler --database=/root/.config/chromium/Crash Reports --annotation=channel=Built on Ubuntu , running on Ubuntu 22.04 --annotation=lsb-release=Ubuntu 22.04.1 LTS --annotation=plat=Linux --annotation=prod=Chrome_Linux --annotation=ver=107.0.5304.121 --initial-client-fd=5 --shared-client-connection
root          32  0.0  0.0   6744  1032 ?        S    21:13   0:00 /usr/lib/chromium-browser/chrome_crashpad_handler --no-periodic-tasks --monitor-self-annotation=ptype=crashpad-handler --database=/root/.config/chromium/Crash Reports --annotation=channel=Built on Ubuntu , running on Ubuntu 22.04 --annotation=lsb-release=Ubuntu 22.04.1 LTS --annotation=plat=Linux --annotation=prod=Chrome_Linux --annotation=ver=107.0.5304.121 --initial-client-fd=4 --shared-client-connection
root          35  0.1  0.1 281700 52156 ?        S    21:13   0:00 /usr/lib/chromium-browser/chromium-browser --type=zygote --no-zygote-sandbox --no-sandbox --enable-crashpad --crashpad-handler-pid=28 --enable-crash-reporter=,Built on Ubuntu , running on Ubuntu 22.04 --user-data-dir=/tmp/chromedp-runner332547841 --change-stack-guard-on-fork=enable --enable-crashpad
root          36  0.2  0.1 281700 53060 ?        S    21:13   0:00 /usr/lib/chromium-browser/chromium-browser --type=zygote --no-sandbox --enable-crashpad --crashpad-handler-pid=28 --enable-crash-reporter=,Built on Ubuntu , running on Ubuntu 22.04 --user-data-dir=/tmp/chromedp-runner332547841 --change-stack-guard-on-fork=enable --enable-crashpad
root          53  0.7  0.1 1359960 64540 ?       Sl   21:13   0:00 /usr/lib/chromium-browser/chromium-browser --type=gpu-process --no-sandbox --disable-dev-shm-usage --disable-breakpad --display=:45 --enable-crashpad --crashpad-handler-pid=28 --enable-crash-reporter=,Built on Ubuntu , running on Ubuntu 22.04 --user-data-dir=/tmp/chromedp-runner332547841 --change-stack-guard-on-fork=enable --gpu-preferences=WAAAAAAAAAAgAAAIAAAAAAAAAAAAAAAAAABgAAAAAAA4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAIAAAAAAAAAABAAAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAAAAAAA== --use-gl=angle --use-angle=swiftshader-webgl --shared-files --field-trial-handle=0,i,16725308680303057551,14291262244193416256,131072 --enable-features=NetworkService,NetworkServiceInProcess --disable-features=BlinkGenPropertyTrees,TranslateUI,site-per-process
root          56  0.4  0.2 945764 67132 ?        Sl   21:13   0:00 /usr/lib/chromium-browser/chromium-browser --type=utility --utility-sub-type=network.mojom.NetworkService --lang=en-US --service-sandbox-type=none --no-sandbox --disable-dev-shm-usage --use-fake-device-for-media-stream --enable-crashpad --crashpad-handler-pid=28 --enable-crash-reporter=,Built on Ubuntu , running on Ubuntu 22.04 --user-data-dir=/tmp/chromedp-runner332547841 --change-stack-guard-on-fork=enable --shared-files=v8_context_snapshot_data:100 --field-trial-handle=0,i,16725308680303057551,14291262244193416256,131072 --enable-features=NetworkService,NetworkServiceInProcess --disable-features=BlinkGenPropertyTrees,TranslateUI,site-per-process --enable-crashpad
root          80  0.0  0.0 577036 24364 ?        Sl   21:13   0:00 /usr/lib/chromium-browser/chromium-browser --type=utility --utility-sub-type=storage.mojom.StorageService --lang=en-US --service-sandbox-type=utility --no-sandbox --disable-dev-shm-usage --use-fake-device-for-media-stream --enable-crashpad --crashpad-handler-pid=28 --enable-crash-reporter=,Built on Ubuntu , running on Ubuntu 22.04 --user-data-dir=/tmp/chromedp-runner332547841 --change-stack-guard-on-fork=enable --shared-files=v8_context_snapshot_data:100 --field-trial-handle=0,i,16725308680303057551,14291262244193416256,131072 --enable-features=NetworkService,NetworkServiceInProcess --disable-features=BlinkGenPropertyTrees,TranslateUI,site-per-process
root         108  0.2  0.2 1185611360 75580 ?    Sl   21:13   0:00 /usr/lib/chromium-browser/chromium-browser --type=renderer --enable-crashpad --crashpad-handler-pid=28 --enable-crash-reporter=,Built on Ubuntu , running on Ubuntu 22.04 --user-data-dir=/tmp/chromedp-runner332547841 --extension-process --display-capture-permissions-policy-allowed --event-path-policy=0 --change-stack-guard-on-fork=enable --no-sandbox --disable-dev-shm-usage --autoplay-policy=no-user-gesture-required --disable-background-timer-throttling --disable-breakpad --force-color-profile=srgb --remote-debugging-port=0 --use-fake-ui-for-media-stream --disable-gpu-compositing --lang=en-US --num-raster-threads=4 --enable-main-frame-before-activation --renderer-client-id=7 --time-ticks-at-unix-epoch=-1673445536441109 --launch-time-ticks=198885543270 --shared-files=v8_context_snapshot_data:100 --field-trial-handle=0,i,16725308680303057551,14291262244193416256,131072 --enabl
root         123  0.2  0.2 1185537460 74960 ?    Sl   21:13   0:00 /usr/lib/chromium-browser/chromium-browser --type=renderer --enable-crashpad --crashpad-handler-pid=28 --enable-crash-reporter=,Built on Ubuntu , running on Ubuntu 22.04 --user-data-dir=/tmp/chromedp-runner332547841 --extension-process --display-capture-permissions-policy-allowed --event-path-policy=0 --change-stack-guard-on-fork=enable --no-sandbox --disable-dev-shm-usage --autoplay-policy=no-user-gesture-required --disable-background-timer-throttling --disable-breakpad --force-color-profile=srgb --remote-debugging-port=0 --use-fake-ui-for-media-stream --disable-databases --disable-gpu-compositing --lang=en-US --num-raster-threads=4 --enable-main-frame-before-activation --renderer-client-id=8 --time-ticks-at-unix-epoch=-1673445536441109 --launch-time-ticks=198885548708 --shared-files=v8_context_snapshot_data:100 --field-trial-handle=0,i,16725308680303057551,142912622441934
root         138  0.7  0.2 1185544704 91236 ?    Sl   21:13   0:00 /usr/lib/chromium-browser/chromium-browser --type=renderer --enable-crashpad --crashpad-handler-pid=28 --enable-crash-reporter=,Built on Ubuntu , running on Ubuntu 22.04 --user-data-dir=/tmp/chromedp-runner332547841 --display-capture-permissions-policy-allowed --event-path-policy=0 --change-stack-guard-on-fork=enable --no-sandbox --disable-dev-shm-usage --autoplay-policy=no-user-gesture-required --disable-background-timer-throttling --disable-breakpad --force-color-profile=srgb --remote-debugging-port=0 --use-fake-ui-for-media-stream --disable-databases --disable-gpu-compositing --lang=en-US --num-raster-threads=4 --enable-main-frame-before-activation --renderer-client-id=12 --time-ticks-at-unix-epoch=-1673445536441109 --launch-time-ticks=198885569765 --shared-files=v8_context_snapshot_data:100 --field-trial-handle=0,i,16725308680303057551,14291262244193416256,131072 --enab
root         191  0.0  0.1 1185168264 51184 ?    Sl   21:13   0:00 /usr/lib/chromium-browser/chromium-browser --type=renderer --enable-crashpad --crashpad-handler-pid=28 --enable-crash-reporter=,Built on Ubuntu , running on Ubuntu 22.04 --user-data-dir=/tmp/chromedp-runner332547841 --display-capture-permissions-policy-allowed --event-path-policy=0 --change-stack-guard-on-fork=enable --no-sandbox --disable-dev-shm-usage --autoplay-policy=no-user-gesture-required --disable-background-timer-throttling --disable-breakpad --force-color-profile=srgb --remote-debugging-port=0 --use-fake-ui-for-media-stream --disable-databases --disable-gpu-compositing --lang=en-US --num-raster-threads=4 --enable-main-frame-before-activation --renderer-client-id=15 --time-ticks-at-unix-epoch=-1673445536441109 --launch-time-ticks=198891690131 --shared-files=v8_context_snapshot_data:100 --field-trial-handle=0,i,16725308680303057551,14291262244193416256,131072 --enab
```

After:

```
calls         24  1.8  0.4 2155072 152952 ?      Sl   20:55   0:00 /usr/lib/chromium-browser/chromium-browser --disable-features=TFLiteLanguageDetectionEnabled --enable-pinch --kiosk --display=:45 --disable-backgrounding-occluded-windows --no-default-browser-check --disable-background-networking --disable-background-timer-throttling --disable-dev-shm-usage --use-fake-device-for-media-stream --no-first-run --disable-hang-monitor --disable-ipc-flooding-protection --disable-renderer-backgrounding --window-position=0,0 --disable-default-apps --use-fake-ui-for-media-stream --unsafely-treat-insecure-origin-as-secure=http://host.docker.internal:8065 --disable-gpu --disable-sync --disable-breakpad --enable-features=NetworkService,NetworkServiceInProcess --disable-client-side-phishing-detection --metrics-recording-only --password-store=basic --window-size=1920,1080 --disable-infobars --disable-popup-blocking --disable-prompt-on-repost --disable-features=site-per-process,TranslateUI,BlinkGenPropertyTrees --force-color-profile=srgb --safebrowsing-disable-auto-update --use-mock-keychain --incognito --autoplay-policy=no-user-gesture-required --disable-extensions --user-data-dir=/tmp/chromedp-runner983171854 --remote-debugging-port=0 about:blank
calls         33  0.0  0.0  14928  3820 ?        Sl   20:55   0:00 /usr/lib/chromium-browser/chrome_crashpad_handler --monitor-self --monitor-self-annotation=ptype=crashpad-handler --database=/home/calls/.config/chromium/Crash Reports --annotation=channel=Built on Ubuntu , running on Ubuntu 22.04 --annotation=lsb-release=Ubuntu 22.04.1 LTS --annotation=plat=Linux --annotation=prod=Chrome_Linux --annotation=ver=109.0.5414.74 --initial-client-fd=5 --shared-client-connection
calls         35  0.0  0.0   6708  1688 ?        S    20:55   0:00 /usr/lib/chromium-browser/chrome_crashpad_handler --no-periodic-tasks --monitor-self-annotation=ptype=crashpad-handler --database=/home/calls/.config/chromium/Crash Reports --annotation=channel=Built on Ubuntu , running on Ubuntu 22.04 --annotation=lsb-release=Ubuntu 22.04.1 LTS --annotation=plat=Linux --annotation=prod=Chrome_Linux --annotation=ver=109.0.5414.74 --initial-client-fd=4 --shared-client-connection
calls         39  0.0  0.1 285144 56064 ?        S    20:55   0:00 /usr/lib/chromium-browser/chromium-browser --type=zygote --no-zygote-sandbox --crashpad-handler-pid=33 --enable-crash-reporter=,Built on Ubuntu , running on Ubuntu 22.04 --user-data-dir=/tmp/chromedp-runner983171854 --change-stack-guard-on-fork=enable
calls         40  0.0  0.1 285136 55792 ?        S    20:55   0:00 /usr/lib/chromium-browser/chromium-browser --type=zygote --crashpad-handler-pid=33 --enable-crash-reporter=,Built on Ubuntu , running on Ubuntu 22.04 --user-data-dir=/tmp/chromedp-runner983171854 --change-stack-guard-on-fork=enable
calls         42  0.0  0.0 285160 14604 ?        S    20:55   0:00 /usr/lib/chromium-browser/chromium-browser --type=zygote --crashpad-handler-pid=33 --enable-crash-reporter=,Built on Ubuntu , running on Ubuntu 22.04 --user-data-dir=/tmp/chromedp-runner983171854 --change-stack-guard-on-fork=enable
calls         60  0.2  0.2 1372256 75828 ?       Sl   20:55   0:00 /usr/lib/chromium-browser/chromium-browser --type=gpu-process --disable-dev-shm-usage --disable-breakpad --display=:45 --crashpad-handler-pid=33 --enable-crash-reporter=,Built on Ubuntu , running on Ubuntu 22.04 --user-data-dir=/tmp/chromedp-runner983171854 --change-stack-guard-on-fork=enable --gpu-preferences=WAAAAAAAAAAgAAAIAAAAAAAAAAAAAAAAAABgAAAAAAA4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAIAAAAAAAAAABAAAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAAAAAAA== --use-gl=angle --use-angle=swiftshader-webgl --shared-files --field-trial-handle=0,i,16249578905243775269,1986949999798556507,131072 --enable-features=NetworkService,NetworkServiceInProcess --disable-features=BlinkGenPropertyTrees,TranslateUI,site-per-process
calls         61  0.3  0.2 949472 71104 ?        Sl   20:55   0:00 /usr/lib/chromium-browser/chromium-browser --type=utility --utility-sub-type=network.mojom.NetworkService --lang=en-US --service-sandbox-type=none --disable-dev-shm-usage --use-fake-device-for-media-stream --crashpad-handler-pid=33 --enable-crash-reporter=,Built on Ubuntu , running on Ubuntu 22.04 --user-data-dir=/tmp/chromedp-runner983171854 --unsafely-treat-insecure-origin-as-secure=http://host.docker.internal:8065 --change-stack-guard-on-fork=enable --shared-files=v8_context_snapshot_data:100 --field-trial-handle=0,i,16249578905243775269,1986949999798556507,131072 --enable-features=NetworkService,NetworkServiceInProcess --disable-features=BlinkGenPropertyTrees,TranslateUI,site-per-process
calls         63  0.0  0.0 654360 26736 ?        Sl   20:55   0:00 /usr/lib/chromium-browser/chromium-browser --type=utility --utility-sub-type=storage.mojom.StorageService --lang=en-US --service-sandbox-type=utility --disable-dev-shm-usage --use-fake-device-for-media-stream --crashpad-handler-pid=33 --enable-crash-reporter=,Built on Ubuntu , running on Ubuntu 22.04 --user-data-dir=/tmp/chromedp-runner983171854 --unsafely-treat-insecure-origin-as-secure=http://host.docker.internal:8065 --change-stack-guard-on-fork=enable --shared-files=v8_context_snapshot_data:100 --field-trial-handle=0,i,16249578905243775269,1986949999798556507,131072 --enable-features=NetworkService,NetworkServiceInProcess --disable-features=BlinkGenPropertyTrees,TranslateUI,site-per-process
calls         98 15.6  0.7 1186453580 256936 ?   Sl   20:55   0:03 /usr/lib/chromium-browser/chromium-browser --type=renderer --crashpad-handler-pid=33 --enable-crash-reporter=,Built on Ubuntu , running on Ubuntu 22.04 --user-data-dir=/tmp/chromedp-runner983171854 --unsafely-treat-insecure-origin-as-secure=http://host.docker.internal:8065 --change-stack-guard-on-fork=enable --disable-dev-shm-usage --autoplay-policy=no-user-gesture-required --disable-background-timer-throttling --disable-breakpad --force-color-profile=srgb --remote-debugging-port=0 --use-fake-ui-for-media-stream --disable-databases --disable-gpu-compositing --lang=en-US --num-raster-threads=4 --enable-main-frame-before-activation --renderer-client-id=5 --time-ticks-at-unix-epoch=-1673445536441109 --launch-time-ticks=197787711505 --shared-files=v8_context_snapshot_data:100 --field-trial-handle=0,i,16249578905243775269,1986949999798556507,131072 --enable-features=Networ
calls        170  0.0  0.1 1185171708 55568 ?    Sl   20:55   0:00 /usr/lib/chromium-browser/chromium-browser --type=renderer --crashpad-handler-pid=33 --enable-crash-reporter=,Built on Ubuntu , running on Ubuntu 22.04 --user-data-dir=/tmp/chromedp-runner983171854 --unsafely-treat-insecure-origin-as-secure=http://host.docker.internal:8065 --change-stack-guard-on-fork=enable --disable-dev-shm-usage --autoplay-policy=no-user-gesture-required --disable-background-timer-throttling --disable-breakpad --force-color-profile=srgb --remote-debugging-port=0 --use-fake-ui-for-media-stream --disable-databases --disable-gpu-compositing --lang=en-US --num-raster-threads=4 --enable-main-frame-before-activation --renderer-client-id=12 --time-ticks-at-unix-epoch=-1673445536441109 --launch-time-ticks=197787759281 --shared-files=v8_context_snapshot_data:100 --field-trial-handle=0,i,16249578905243775269,1986949999798556507,131072 --enable-features=Netwo
calls        195  1.5  0.1 1083560 62560 ?       Sl   20:55   0:00 /usr/lib/chromium-browser/chromium-browser --type=utility --utility-sub-type=audio.mojom.AudioService --lang=en-US --service-sandbox-type=none --disable-dev-shm-usage --use-fake-device-for-media-stream --crashpad-handler-pid=33 --enable-crash-reporter=,Built on Ubuntu , running on Ubuntu 22.04 --user-data-dir=/tmp/chromedp-runner983171854 --unsafely-treat-insecure-origin-as-secure=http://host.docker.internal:8065 --change-stack-guard-on-fork=enable --shared-files=v8_context_snapshot_data:100 --field-trial-handle=0,i,16249578905243775269,1986949999798556507,131072 --enable-features=NetworkService,NetworkServiceInProcess --disable-features=BlinkGenPropertyTrees,TranslateUI,site-per-process
```

#### Related PR

https://github.com/mattermost/calls-offloader/pull/15

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49667
