### PR TITLE
[MM-49683] Automated pinned packages generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -352,6 +352,10 @@ else
 endif
 	@$(OK) Generating github-release http://github.com/$(GITHUB_ORG)/$(GITHUB_REPO)/releases/tag/$(APP_VERSION) ...
 
+.PHONY: go-pinned-packages
+go-pinned-packages: ## to update pinned packages list for the Ubuntu based Docker image
+	go run ./build/generator.go
+
 .PHONY: clean
 clean: ## to clean-up
 	@$(INFO) cleaning /${GO_OUT_BIN_DIR} folder...

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,15 +14,11 @@ RUN sed -i -e 's/^APT/# APT/' -e 's/^DPkg/# DPkg/' /etc/apt/apt.conf.d/docker-cl
 
 ARG CHROMIUM_VERSION=109.0.5414.74-0
 ARG DEBIAN_FRONTEND=noninteractive
+COPY ./build/pkgs_list .
+# hadolint ignore=DL3008,SC2046
 RUN set -ex && \
     apt-get update && \
-    apt-get install --no-install-recommends -y \
-      ffmpeg=7:4.4.2-0ubuntu0.22.04.1 \
-      pulseaudio=1:15.99.1+dfsg1-1ubuntu2 \
-      xvfb=2:21.1.3* wget=1.21.2-2ubuntu1 \
-      unzip=6.0-26ubuntu3.1 \
-      fonts-emojione=2.2.6+16.10.20160804-0ubuntu2 \
-      ca-certificates=20211016 && \
+    apt-get install --no-install-recommends -y $(cat pkgs_list) && \
     apt-get update && \
     wget --progress=dot:giga -N \
       -O chromium-chromedriver.deb \

--- a/build/generator.go
+++ b/build/generator.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	launchpadAPIBaseURL = "https://api.launchpad.net/1.0"
+	distroName          = "ubuntu"
+	distroVersion       = "jammy"
+	distroArch          = "amd64"
+
+	pkgsListPath = "./build/pkgs_list"
+
+	requestTimeout = 5 * time.Second
+)
+
+type Package struct {
+	Name    string
+	Version string
+}
+
+func GetPublishedPackages(c *http.Client, names []string) ([]Package, error) {
+	var pkgs []Package
+
+	for _, pkgName := range names {
+		ctx, cancelFn := context.WithTimeout(context.Background(), requestTimeout)
+		defer cancelFn()
+
+		url := fmt.Sprintf("%s/%s/+archive/primary", launchpadAPIBaseURL, distroName)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("request creation: %w", err)
+		}
+
+		q := req.URL.Query()
+		q.Add("ws.op", "getPublishedBinaries")
+		q.Add("binary_name", pkgName)
+		q.Add("exact_match", "true")
+		q.Add("distro_arch_series", fmt.Sprintf("%s/%s/%s/%s", launchpadAPIBaseURL, distroName, distroVersion, distroArch))
+		q.Add("status", "Published")
+		q.Add("order_by_date", "true")
+		req.URL.RawQuery = q.Encode()
+
+		resp, err := c.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("request failed: %w", err)
+		}
+
+		respData := map[string]any{}
+		if err := json.NewDecoder(resp.Body).Decode(&respData); err != nil {
+			return nil, fmt.Errorf("failed to decode response: %w", err)
+		}
+
+		entries, ok := respData["entries"].([]any)
+		if !ok {
+			return nil, fmt.Errorf("failed to parse response")
+		}
+
+		if len(entries) == 0 {
+			break
+		}
+
+		entry, ok := entries[0].(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("failed to parse entry")
+		}
+
+		name, ok := entry["binary_package_name"].(string)
+		if !ok {
+			return nil, fmt.Errorf("failed to parse package name")
+		}
+
+		version, ok := entry["binary_package_version"].(string)
+		if !ok {
+			return nil, fmt.Errorf("failed to parse package version")
+		}
+
+		log.Printf("found %s=%s\n", name, version)
+
+		pkgs = append(pkgs, Package{Name: name, Version: version})
+	}
+
+	return pkgs, nil
+}
+
+func GenPinnedPackages(pkgsNames []string) error {
+	c := &http.Client{}
+
+	pkgs, err := GetPublishedPackages(c, pkgsNames)
+	if err != nil {
+		return fmt.Errorf("failed to get packages: %w", err)
+	}
+
+	outFile, err := os.OpenFile(pkgsListPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
+	if err != nil {
+		return fmt.Errorf("failed to open output file: %w", err)
+	}
+	defer outFile.Close()
+
+	for _, pkg := range pkgs {
+		fmt.Fprintf(outFile, "%s=%s\n", pkg.Name, pkg.Version)
+	}
+
+	return nil
+}
+
+func parsePkgsList(data string) []string {
+	var pkgs []string
+	list := strings.Split(data, "\n")
+	for _, el := range list {
+		name, _, _ := strings.Cut(el, "=")
+		pkgs = append(pkgs, name)
+	}
+	return pkgs
+}
+
+func main() {
+	data, err := os.ReadFile(pkgsListPath)
+	if err != nil {
+		log.Fatalf("failed to read packages file: %s", err)
+	}
+
+	if err := GenPinnedPackages(parsePkgsList(string(data))); err != nil {
+		log.Fatalf("failed to generate pinned packages: %s", err)
+	}
+
+	log.Printf("done")
+}

--- a/build/pkgs_list
+++ b/build/pkgs_list
@@ -1,0 +1,7 @@
+ca-certificates=20211016ubuntu0.22.04.1
+ffmpeg=7:4.4.2-0ubuntu0.22.04.1
+fonts-emojione=2.2.6+16.10.20160804-0ubuntu2
+pulseaudio=1:15.99.1+dfsg1-1ubuntu2
+unzip=6.0-26ubuntu3.1
+wget=1.21.2-2ubuntu1
+xvfb=2:21.1.3-2ubuntu2.5


### PR DESCRIPTION
#### Summary

PR implements a simple tool to automatically generate updated pinned packages from a given list. A new `make go-pinned-packages` is introduced to do that.

Eventually I'd like to extend this to Chromium which is handled a bit differently but should be similarly applicable. 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49683
