### PR TITLE
[MM-50394] Properly relay recorder's exit code

### DIFF
--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -13,15 +13,41 @@ pactl load-module module-null-sink sink_name="grab" sink_properties=device.descr
 # Forward signals to service
 RECORDER_PID=0
 RECORDER_PID_FILE=/tmp/recorder.pid
+RECORDER_EXIT_CODE=143 # 128 + 15 -- SIGTERM
+RECORDER_EXIT_CODE_FILE=/tmp/recorder.ecode
 
 # SIGTERM handler
 term_handler() {
-  RECORDER_PID=`cat $RECORDER_PID_FILE`
-  if [ $RECORDER_PID -ne 0 ]; then
-    kill -SIGTERM "$RECORDER_PID"
-    tail --pid="$RECORDER_PID" -f /dev/null
+  # If pid file doesn't exit we exit with failure
+  # as the recording process hasn't started properly.
+  if [ ! -f "$RECORDER_PID_FILE" ]; then
+    echo "pid not found"
+    exit 1
   fi
-  exit 143; # 128 + 15 -- SIGTERM
+
+  RECORDER_PID=`cat $RECORDER_PID_FILE`
+
+  # Relaying the SIGTERM to the recorder's process.
+  kill -SIGTERM "$RECORDER_PID"
+  # Wait for the recorder's process to exit.
+  tail --pid="$RECORDER_PID" -f /dev/null
+
+  # Wait a second for the recorder's exit code to be saved.
+  sleep 1
+
+  # If exit code file doesn't exit we exit with failure.
+  if [ ! -f "$RECORDER_EXIT_CODE_FILE" ]; then
+    echo "exit code not found"
+    exit 1
+  fi
+
+  EXIT_CODE=`cat $RECORDER_EXIT_CODE_FILE`
+
+  # Sum the recorder's exit code to the base exit code to
+  # inform the job handler in case of failure.
+  RECORDER_EXIT_CODE=$(($RECORDER_EXIT_CODE+$EXIT_CODE))
+
+  exit $RECORDER_EXIT_CODE;
 }
 
 # On callback, kill the last background process, which is `tail -f /dev/null` and execute the specified handler
@@ -43,7 +69,7 @@ runuser -l $RECORDER_USER -c \
   THREAD_ID=$THREAD_ID \
   DEV_MODE=$DEV \
   XDG_RUNTIME_DIR=/home/$RECORDER_USER/.cache/xdgr \
-  /opt/calls-recorder/bin/calls-recorder" &
+  /bin/bash -c '/opt/calls-recorder/bin/calls-recorder; echo \$? > ${RECORDER_EXIT_CODE_FILE}'" &
 
 # Wait forever
 wait ${!}


### PR DESCRIPTION
#### Summary

We weren't properly relaying the recorder process exit code which meant that in case of internal failure (e.g. the recorder failing to upload a recording) the `calls-offloader` would read the SIGTERM signal and consider the job successful, leading to improper data deletion.

Unfortunately `bash` plus all the tricks we applied to make this run as non root didn't make it easy to do this cleanly so I really had to figure out a less than beautiful workaround involving another temp file. 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-50394
