### PR TITLE
Fix CI build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,11 @@ MAKEFLAGS     += --warn-undefined-variables
 CONFIG_APP_CODE         += ./cmd/recorder
 
 # Operating system arch
+ifneq (, $(shell which go))
 ARCH                    ?= $(shell go version | awk '{print substr($$4,index($$4,"/")+1)}')
+endif
+# Fallback to amd64 if ARCH is still unset.
+ARCH                    ?= amd64
 
 ## Docker Variables
 # Docker executable

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,10 +10,6 @@ FROM ${RUNNER_IMAGE:?} as base
 # Setup system dependencies
 WORKDIR /workdir
 
-# Workaround for Ubuntu 22.04 `apt update` failing when running under Docker < 20.10.9
-# https://stackoverflow.com/questions/71941032/why-i-cannot-run-apt-update-inside-a-fresh-ubuntu22-04
-RUN sed -i -e 's/^APT/# APT/' -e 's/^DPkg/# DPkg/' /etc/apt/apt.conf.d/docker-clean
-
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY ./build/pkgs_list .


### PR DESCRIPTION
#### Summary

Fixing an issue in case Golang is not installed we fallback to `amd64` which is our officially supported docker image target.
Also, now that Docker is upgraded on the CI runner (thanks @phoinixgrr) we can remove the `apt-get` hack.


