### PR TITLE
Bump request timeout

### DIFF
--- a/build/generator.go
+++ b/build/generator.go
@@ -25,7 +25,7 @@ const (
 
 	pkgsListPath = "./pkgs_list"
 
-	requestTimeout = 5 * time.Second
+	requestTimeout = 30 * time.Second
 )
 
 type Package struct {


### PR DESCRIPTION
#### Summary

It can take a bit more than 5 seconds to read the whole response's body, especially since we are effectively streaming it to the parser.

