### PR TITLE
Enable e2e testing

### DIFF
--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -5,7 +5,7 @@ set -euxo pipefail
 rm -rf /var/run/pulse /var/lib/pulse /root/.config/pulse
 
 # Start pulseaudio as system wide daemon; for debugging it helps to start in non-daemon mode
-pulseaudio -D --verbose --exit-idle-time=-1 --system --disallow-exit
+pulseaudio -D --verbose --exit-idle-time=-1 --system --disallow-exit --disable-shm=true --log-time=true
 
 # Load audio sink
 pactl load-module module-null-sink sink_name="grab" sink_properties=device.description="monitorOUT"

--- a/build/pkgs_list
+++ b/build/pkgs_list
@@ -1,7 +1,8 @@
 ca-certificates=20211016
 chromium=110.0.5481.77-2
 chromium-driver=110.0.5481.77-2
-ffmpeg=7:5.1.2-2
+chromium-sandbox=110.0.5481.77-2
+ffmpeg=7:5.1.2-3
 fonts-recommended=1
 pulseaudio=16.1+dfsg1-2+b1
 wget=1.21.3-1+b2

--- a/cmd/recorder/recorder.go
+++ b/cmd/recorder/recorder.go
@@ -86,8 +86,9 @@ func (rec *Recorder) runBrowser(recURL string) error {
 		chromedp.WithErrorf(log.Printf),
 	}
 	if devMode := os.Getenv("DEV_MODE"); devMode == "true" {
-		opts = append(opts, chromedp.Flag("unsafely-treat-insecure-origin-as-secure", "http://172.17.0.1:8065"))
-		opts = append(opts, chromedp.Flag("unsafely-treat-insecure-origin-as-secure", "http://host.docker.internal:8065"))
+		opts = append(opts, chromedp.Flag("unsafely-treat-insecure-origin-as-secure",
+			"http://172.17.0.1:8065,http://host.docker.internal:8065,http://mm-server:8065"))
+		opts = append(opts, chromedp.NoSandbox)
 		contextOpts = append(contextOpts, chromedp.WithLogf(log.Printf))
 		contextOpts = append(contextOpts, chromedp.WithDebugf(log.Printf))
 	}


### PR DESCRIPTION
#### Summary

Applying a couple of changes to make e2e tests happy:

- Running chrome without sandbox when `DEV_MODE=true`.
- Adding the `mm-server` host to allowed insecure origins so that the recorder can connect successfully to a non-localhost instance.

