### PR TITLE
[MM-51439] Improve command output logging

### DIFF
--- a/cmd/recorder/cmd.go
+++ b/cmd/recorder/cmd.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"io"
+	"log"
+	"os/exec"
+	"strings"
+)
+
+const (
+	logBufferSize = 1024 * 64 // 64KB
+)
+
+func runCmd(cmd string, args string) (*exec.Cmd, error) {
+	log.Printf("running %s: %q", cmd, args)
+	c := exec.Command(cmd, strings.Split(args, " ")...)
+
+	stdout, err := c.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	stderr, err := c.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	logOutput := func(out io.ReadCloser, name string) {
+		defer out.Close()
+		buf := make([]byte, logBufferSize)
+		for {
+			n, err := out.Read(buf)
+			if err != nil {
+				log.Printf("%s (%s): error reading: %s", cmd, name, err)
+				return
+			}
+			log.Printf("%s (%s): %s\n", cmd, name, strings.TrimSuffix(string(buf[:n]), "\n"))
+		}
+	}
+
+	go logOutput(stdout, "stdout")
+	go logOutput(stderr, "stderr")
+
+	return c, c.Start()
+}

--- a/cmd/recorder/cmd_test.go
+++ b/cmd/recorder/cmd_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunCmd(t *testing.T) {
+	t.Run("non-existant command", func(t *testing.T) {
+		cmd, err := runCmd("calls", "")
+		require.Error(t, err)
+		require.Nil(t, cmd)
+	})
+
+	t.Run("valid command", func(t *testing.T) {
+		cmd, err := runCmd("ls", ".")
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+		require.NoError(t, cmd.Wait())
+	})
+}


### PR DESCRIPTION
#### Summary

Recordings were suddenly stopping after ~10 minutes. Initial investigation lead to the discovery of an out-of-memory kill on `Xvfb`, the virtual framebuffer process where our Chromium browser renders to. This was quite unexpected since of all the processes we spawn, the framebuffer should be the most lightweight. Even more surprising was that the leak wasn't happening as the recording started but consistently appeared after almost exactly 10 minutes and from the on it was a matter of seconds before all the memory available was taken.

It took a while to figure out that `ffmpeg` was on average printing ~100 characters per second on `stderr` and the default pipe size is 64K, meaning ~655 seconds of "capacity" without being drained. We had a `bufio.Scanner` in place but turns out that `ffmpeg`'s output after some initial burst is in place, with no new lines appearing so the scanner wasn't doing anything and data was constantly accumulating. 

Now comes the good part. Golang is smart enough to error out (although we failed to add a check for it) and `ffmpeg` is smart enough to continue if the logs pipe gets full (I even checked the `strace` output and write syscalls were still going forward so nothing was blocked). But for some reason, yet to be determined, `Xfvb` wasn't happy with this state and started leaking memory like crazy. 

I'd love to dig deeper on this because the fix alone is not very satisfying but at the same time I didn't want to delay proceedings further as the issue is currently affecting production systems.

#### Memory spikes

![image](https://user-images.githubusercontent.com/1832946/225446827-2d4844d4-8fd8-43ec-86a8-9eac601e0e37.png)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51439
