### PR TITLE
[MM-51953] Be resilient to multiple SIGTERM signals

### DIFF
--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -18,6 +18,10 @@ RECORDER_EXIT_CODE_FILE=/tmp/recorder.ecode
 
 # SIGTERM handler
 term_handler() {
+  # We unsubscribe the handler to avoid issues if receiving another
+  # SIGTERM while in here (e.g. stopping twice).
+  trap - SIGTERM
+
   # If pid file doesn't exit we exit with failure
   # as the recording process hasn't started properly.
   if [ ! -f "$RECORDER_PID_FILE" ]; then


### PR DESCRIPTION
#### Summary

It took a bit to figure out but the core issue here but this is what's happening. Upon timeout (recording lasting more than the configured `MaxRecordingDuration`) the following happens:

1. `calls-offloader` attempts to stop the docker container.
2. Docker sends a `SIGTERM` to the main process.
3. The handler in `entrypoint.sh` executes, forwarding the signal to the recorder process.
4. The recorder receives the signal and starts shutting down, starting with the chromium process.
5. At this point the plugin side figures out the bot session disconnected and [attempts to stop the job through the API](https://github.com/mattermost/mattermost-plugin-calls/blob/93c3bc5bf5a0d8b4099f54f04bbe5d8cdaaa83f2/server/session.go#L310-L314).
6. Everything repeats from point 1 forward but the recorder process is already gone by now and it fails to get killed.

To fix this easily without much coordination (e.g. locking the stop operation) we are simply unsubscribing the term handler upon first execution.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51953
