### PR TITLE
Fix potential panic in case of API response error

### DIFF
--- a/cmd/recorder/upload.go
+++ b/cmd/recorder/upload.go
@@ -47,10 +47,10 @@ func (rec *Recorder) uploadRecording() error {
 	ctx, cancelCtx := context.WithTimeout(context.Background(), httpRequestTimeout)
 	defer cancelCtx()
 	resp, err := client.DoAPIRequestBytes(ctx, http.MethodPost, apiURL+"/uploads", payload, "")
-	defer resp.Body.Close()
 	if err != nil {
 		return fmt.Errorf("failed to create upload (%d): %w", resp.StatusCode, err)
 	}
+	defer resp.Body.Close()
 	cancelCtx()
 
 	if err := json.NewDecoder(resp.Body).Decode(&us); err != nil {
@@ -60,10 +60,10 @@ func (rec *Recorder) uploadRecording() error {
 	ctx, cancelCtx = context.WithTimeout(context.Background(), httpUploadTimeout)
 	defer cancelCtx()
 	resp, err = client.DoAPIRequestReader(ctx, http.MethodPost, apiURL+"/uploads/"+us.Id, file, nil)
-	defer resp.Body.Close()
 	if err != nil {
 		return fmt.Errorf("failed to upload data (%d): %w", resp.StatusCode, err)
 	}
+	defer resp.Body.Close()
 	cancelCtx()
 
 	// TODO (MM-48545): handle upload resumption.
@@ -85,10 +85,10 @@ func (rec *Recorder) uploadRecording() error {
 	ctx, cancelCtx = context.WithTimeout(context.Background(), httpRequestTimeout)
 	defer cancelCtx()
 	resp, err = client.DoAPIRequestBytes(ctx, http.MethodPost, url, payload, "")
-	defer resp.Body.Close()
 	if err != nil {
 		return fmt.Errorf("failed to save recording (%d): %w", resp.StatusCode, err)
 	}
+	defer resp.Body.Close()
 
 	return nil
 }


### PR DESCRIPTION
#### Summary

The response body should be closed only if the request has not failed or it would cause a panic.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x87c46a]

goroutine 1 [running]:
main.(*Recorder).uploadRecording(0xc000344000)
	github.com/mattermost/calls-recorder/cmd/recorder/upload.go:50 +0x52a
main.(*Recorder).Stop(0xc000344000)
	github.com/mattermost/calls-recorder/cmd/recorder/recorder.go:305 +0x285
main.main()
	github.com/mattermost/calls-recorder/cmd/recorder/main.go:46 +0x4b9
+ exit_handler
+ '[' '!' -f /tmp/recorder.ecode ']'
++ cat /tmp/recorder.ecode
+ EXIT_CODE=2
+ exit 2
```


