### PR TITLE
[MM-54326] Fix panic on HTTP request error

### DIFF
--- a/cmd/recorder/upload.go
+++ b/cmd/recorder/upload.go
@@ -48,7 +48,7 @@ func (rec *Recorder) uploadRecording() error {
 	defer cancelCtx()
 	resp, err := client.DoAPIRequestBytes(ctx, http.MethodPost, apiURL+"/uploads", payload, "")
 	if err != nil {
-		return fmt.Errorf("failed to create upload (%d): %w", resp.StatusCode, err)
+		return fmt.Errorf("failed to create upload: %w", err)
 	}
 	defer resp.Body.Close()
 	cancelCtx()
@@ -61,7 +61,7 @@ func (rec *Recorder) uploadRecording() error {
 	defer cancelCtx()
 	resp, err = client.DoAPIRequestReader(ctx, http.MethodPost, apiURL+"/uploads/"+us.Id, file, nil)
 	if err != nil {
-		return fmt.Errorf("failed to upload data (%d): %w", resp.StatusCode, err)
+		return fmt.Errorf("failed to upload data: %w", err)
 	}
 	defer resp.Body.Close()
 	cancelCtx()
@@ -86,7 +86,7 @@ func (rec *Recorder) uploadRecording() error {
 	defer cancelCtx()
 	resp, err = client.DoAPIRequestBytes(ctx, http.MethodPost, url, payload, "")
 	if err != nil {
-		return fmt.Errorf("failed to save recording (%d): %w", resp.StatusCode, err)
+		return fmt.Errorf("failed to save recording: %w", err)
 	}
 	defer resp.Body.Close()
 

--- a/cmd/recorder/upload_test.go
+++ b/cmd/recorder/upload_test.go
@@ -63,7 +63,7 @@ func TestUploadRecording(t *testing.T) {
 			},
 		}
 		err := rec.uploadRecording()
-		require.EqualError(t, err, "failed to create upload (400): : server error")
+		require.EqualError(t, err, "failed to create upload: : server error")
 	})
 
 	t.Run("upload data failure", func(t *testing.T) {
@@ -87,7 +87,7 @@ func TestUploadRecording(t *testing.T) {
 			},
 		}
 		err := rec.uploadRecording()
-		require.EqualError(t, err, "failed to upload data (400): : server error")
+		require.EqualError(t, err, "failed to upload data: : server error")
 	})
 
 	t.Run("save recording failure", func(t *testing.T) {
@@ -119,7 +119,7 @@ func TestUploadRecording(t *testing.T) {
 			},
 		}
 		err := rec.uploadRecording()
-		require.EqualError(t, err, "failed to save recording (400): : server error")
+		require.EqualError(t, err, "failed to save recording: : server error")
 	})
 
 	t.Run("success", func(t *testing.T) {


### PR DESCRIPTION
#### Summary

A failed HTTP request could cause a `nil` response to be returned so we cannot reliably use that to log the HTTP code.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54326
