### PR TITLE
[MM-53432] Improve recording start time accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ docker pull mattermost/calls-recorder:latest
 ### Run the container
 
 ```
-docker run --network=host --name calls-recorder -e "SITE_URL=http://127.0.0.1:8065/" -e "AUTH_TOKEN=ohqd1phqtt8m3gsfg8j5ymymqy" -e "CALL_ID=9c86b3q57fgfpqr8jq3b9yjweh" -e "THREAD_ID=e4pdmi6rqpn7pp9sity9hiza3r" -e "DEV_MODE=true" -v calls-recorder-volume:/recs mattermost/calls-recorder
+docker run --network=host --name calls-recorder -e "SITE_URL=http://127.0.0.1:8065/" -e "AUTH_TOKEN=ohqd1phqtt8m3gsfg8j5ymymqy" -e "CALL_ID=9c86b3q57fgfpqr8jq3b9yjweh" -e "THREAD_ID=e4pdmi6rqpn7pp9sity9hiza3r" -e "DEV_MODE=true" -v calls-recorder-volume:/data mattermost/calls-recorder
 ```
 
 > **_Note_** 

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -59,7 +59,7 @@ trap 'kill ${!}; term_handler' SIGTERM
 RECORDER_USER=calls
 
 # Give permission to write recording files.
-chown -R $RECORDER_USER:$RECORDER_USER /recs
+chown -R $RECORDER_USER:$RECORDER_USER /data
 # Give permissions to home directory so that Chromium can create any
 # necessary files and directories.
 chown -R $RECORDER_USER:$RECORDER_USER /home/$RECORDER_USER

--- a/build/pkgs_list
+++ b/build/pkgs_list
@@ -1,7 +1,7 @@
 ca-certificates=20230311
-chromium=116.0.5845.180-1
-chromium-driver=116.0.5845.180-1
-chromium-sandbox=116.0.5845.180-1
+chromium=117.0.5938.62-1
+chromium-driver=117.0.5938.62-1
+chromium-sandbox=117.0.5938.62-1
 ffmpeg=7:6.0-6
 fonts-recommended=1
 pulseaudio=16.1+dfsg1-2+b1

--- a/build/pkgs_list
+++ b/build/pkgs_list
@@ -1,9 +1,9 @@
 ca-certificates=20230311
-chromium=116.0.5845.140-1
-chromium-driver=116.0.5845.140-1
-chromium-sandbox=116.0.5845.140-1
+chromium=116.0.5845.180-1
+chromium-driver=116.0.5845.180-1
+chromium-sandbox=116.0.5845.180-1
 ffmpeg=7:6.0-6
 fonts-recommended=1
 pulseaudio=16.1+dfsg1-2+b1
-wget=1.21.3-1+b2
+wget=1.21.4-1+b1
 xvfb=2:21.1.8-1

--- a/cmd/recorder/config/config.go
+++ b/cmd/recorder/config/config.go
@@ -175,6 +175,10 @@ func (cfg *RecorderConfig) SetDefaults() {
 }
 
 func (cfg RecorderConfig) ToEnv() []string {
+	if cfg == (RecorderConfig{}) {
+		return nil
+	}
+
 	return []string{
 		fmt.Sprintf("SITE_URL=%s", cfg.SiteURL),
 		fmt.Sprintf("CALL_ID=%s", cfg.CallID),
@@ -192,6 +196,10 @@ func (cfg RecorderConfig) ToEnv() []string {
 }
 
 func (cfg RecorderConfig) ToMap() map[string]any {
+	if cfg == (RecorderConfig{}) {
+		return nil
+	}
+
 	return map[string]any{
 		"site_url":      cfg.SiteURL,
 		"call_id":       cfg.CallID,

--- a/cmd/recorder/main.go
+++ b/cmd/recorder/main.go
@@ -29,10 +29,15 @@ func main() {
 		log.Fatalf("failed to create recorder: %s", err)
 	}
 
-	log.Printf("starting recordinig")
+	log.Printf("starting recording")
 
 	if err := recorder.Start(); err != nil {
-		log.Fatalf("failed to start recording: %s", err)
+		log.Printf("failed to start recording: %s", err)
+		// cleaning up
+		if err := recorder.Stop(); err != nil {
+			log.Printf("failed to stop recorder: %s", err)
+		}
+		os.Exit(1)
 	}
 
 	log.Printf("recording has started")

--- a/cmd/recorder/recorder.go
+++ b/cmd/recorder/recorder.go
@@ -28,6 +28,7 @@ const (
 	uploadRetryAttemptWaitTime = 5 * time.Second
 	initPollInterval           = 250 * time.Millisecond
 	connCheckInterval          = 1 * time.Second
+	dataDir                    = "/data"
 )
 
 type Recorder struct {
@@ -271,7 +272,7 @@ func (rec *Recorder) Start() error {
 	log.Printf("browser connected, ready to record")
 
 	filename := fmt.Sprintf("%s-%s.mp4", rec.cfg.CallID, time.Now().UTC().Format("2006-01-02-15_04_05"))
-	rec.outPath = filepath.Join("/recs", filename)
+	rec.outPath = filepath.Join(dataDir, filename)
 	err = rec.runTranscoder(rec.outPath)
 	if err != nil {
 		return fmt.Errorf("failed to run transcoder: %s", err)

--- a/cmd/recorder/utils.go
+++ b/cmd/recorder/utils.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"regexp"
 )
 
@@ -10,4 +11,11 @@ var (
 
 func sanitizeConsoleLog(str string) string {
 	return icePasswordRE.ReplaceAllString(str, "ice-pwd:XXX")
+}
+
+func getDataDir() string {
+	if dir := os.Getenv("DATA_DIR"); dir != "" {
+		return dir
+	}
+	return dataDir
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/chromedp/chromedp v0.9.2
 	github.com/mattermost/mattermost/server/public v0.0.0-20230613002302-62a3ee8adcb5
 	github.com/stretchr/testify v1.8.2
+	golang.org/x/time v0.0.0-20181108054448-85acf8d2951c
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -245,6 +245,7 @@ golang.org/x/text v0.5.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.9.0 h1:2sjJmO8cDvYveuX97RDLsxlyUxLl+GHoLxBiRdHllBE=
 golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20181108054448-85acf8d2951c h1:fqgJT0MGcGpPgpWU7VRdRjuArfcOvC4AoJmILihzhDg=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
#### Summary

PR improves the accuracy of the recording job start time so that it becomes a little easier to synchronize future transcriptions. 
We do this by plugging into `ffmpeg`'s progress log and send a ws event to the stream when the actual transcoding process starts.

Semantically the change is that a recording doesn't start any longer when the bot connects via websocket but when it sends this new `job_started` event since it could happen a few seconds later as the transcoding process needs a couple of seconds to initialize.

Other notable changes included here:

- Start using the generic `/data` dir to store files. Same happens on the transcriber and it makes it just easier to generalize jobs at the offloader level.
- Bumping Chromium (finally) to fix a recent SEGFAULT on Debian.
- Generally tried to make the whole stop sequence a little more robust but still need to implement proper cancellation ([MM-54485](https://mattermost.atlassian.net/browse/MM-54485))

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-53432
