### PR TITLE
[MM-54579] Fix display server startup error

### DIFF
--- a/build/pkgs_list
+++ b/build/pkgs_list
@@ -1,9 +1,9 @@
 ca-certificates=20230311
-chromium=116.0.5845.140-1
-chromium-driver=116.0.5845.140-1
-chromium-sandbox=116.0.5845.140-1
-ffmpeg=7:6.0-6
+chromium=117.0.5938.132-1
+chromium-driver=117.0.5938.132-1
+chromium-sandbox=117.0.5938.132-1
+ffmpeg=7:6.0-7
 fonts-recommended=1
 pulseaudio=16.1+dfsg1-2+b1
-wget=1.21.3-1+b2
+wget=1.21.4-1+b1
 xvfb=2:21.1.8-1

--- a/cmd/recorder/recorder.go
+++ b/cmd/recorder/recorder.go
@@ -9,13 +9,14 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
 
 	"github.com/mattermost/calls-recorder/cmd/recorder/config"
 
-	"github.com/chromedp/cdproto/runtime"
+	cruntime "github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/chromedp"
 )
 
@@ -101,12 +102,12 @@ func (rec *Recorder) runBrowser(recURL string) error {
 
 	chromedp.ListenTarget(ctx, func(ev interface{}) {
 		switch ev := ev.(type) {
-		case *runtime.EventExceptionThrown:
+		case *cruntime.EventExceptionThrown:
 			log.Printf("chrome exception: %s", ev.ExceptionDetails.Text)
 			if ev.ExceptionDetails.Exception != nil {
 				log.Printf("chrome exception: %s", ev.ExceptionDetails.Exception.Description)
 			}
-		case *runtime.EventConsoleAPICalled:
+		case *cruntime.EventConsoleAPICalled:
 			args := make([]string, 0, len(ev.Args))
 			for _, arg := range ev.Args {
 				var val interface{}
@@ -240,6 +241,16 @@ func NewRecorder(cfg config.RecorderConfig) (*Recorder, error) {
 }
 
 func (rec *Recorder) Start() error {
+	// Verify that the required sysctl is set.
+	if runtime.GOOS == "linux" {
+		if data, err := os.ReadFile("/proc/sys/kernel/unprivileged_userns_clone"); err != nil {
+			return fmt.Errorf("failed to read sysctl: %w", err)
+		} else if strings.TrimSpace(string(data)) != "1" {
+			return fmt.Errorf("kernel.unprivileged_userns_clone should be enabled for the recording process to work")
+		}
+		log.Printf("kernel.unprivileged_userns_clone is correctly set")
+	}
+
 	var err error
 	rec.displayServer, err = runDisplayServer(rec.cfg.Width, rec.cfg.Height)
 	if err != nil {

--- a/cmd/recorder/recorder.go
+++ b/cmd/recorder/recorder.go
@@ -223,7 +223,7 @@ func (rec *Recorder) runTranscoder(dst string) error {
 }
 
 func runDisplayServer(width, height int) (*exec.Cmd, error) {
-	args := fmt.Sprintf(`:%d -screen 0 %dx%dx24 -dpi 96`, displayID, width, height)
+	args := fmt.Sprintf(`:%d -screen 0 %dx%dx24 -dpi 96 -nolisten tcp -nolisten unix`, displayID, width, height)
 	return runCmd("Xvfb", args)
 }
 


### PR DESCRIPTION
#### Summary

PR fixes a recurring error when starting the display server (`Xvfb`). 

Unfortunately, after further logs inspection, this error always existed and never caused issues so the failures we experienced on Community are most likely unrelated but have to do with the browser process not starting correctly instead. To help with this we add a check to verify the required `sysctl` is actually set on start.

If the problem persists we may need to enable debug logs to get more insights on the root cause.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54579

