### PR TITLE
[MM-54747] Implement structured logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.18.x]
+        go-version: [1.21.x]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -7,7 +7,7 @@ jobs:
     name: lint
     strategy:
       matrix:
-        go-version: [1.18.x]
+        go-version: [1.21.x]
     runs-on: ubuntu-latest
     steps:
       - name: Install Go

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.50.1
+          version: v1.54.2
 
           # Optional: if set to true then the action will use pre-installed Go.
           skip-go-installation: true

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ DOCKER_USER             ?= user
 DOCKER_PASSWORD         ?= password
 ## Docker Images
 DOCKER_IMAGE_GO         += "golang:${GO_VERSION}@sha256:b17c35044f4062d83c815434615997eed97697daae8745c6dd39dc3673b87efb"
-DOCKER_IMAGE_GOLINT     += "golangci/golangci-lint:v1.50.1@sha256:94388e00f07c64262b138a7508f857473e30fdf0f59d04b546a305fc12cb5961"
+DOCKER_IMAGE_GOLINT     += "golangci/golangci-lint:v1.54.2@sha256:abe731fe6bb335a30eab303a41dd5c2b630bb174372a4da08e3d42eab5324127"
 DOCKER_IMAGE_DOCKERLINT += "hadolint/hadolint:v2.9.2@sha256:d355bd7df747a0f124f3b5e7b21e9dafd0cb19732a276f901f0fdee243ec1f3b"
 DOCKER_IMAGE_COSIGN     += "bitnami/cosign:1.8.0@sha256:8c2c61c546258fffff18b47bb82a65af6142007306b737129a7bd5429d53629a"
 DOCKER_IMAGE_GH_CLI     += "registry.internal.mattermost.com/images/build-ci:3.16.0@sha256:f6a229a9ababef3c483f237805ee4c3dbfb63f5de4fbbf58f4c4b6ed8fcd34b6"

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ DOCKER_REGISTRY_REPO    ?= mattermost/${APP_NAME}-daily
 DOCKER_USER             ?= user
 DOCKER_PASSWORD         ?= password
 ## Docker Images
-DOCKER_IMAGE_GO         += "golang:${GO_VERSION}@sha256:fa71e1447cb0241324162a6c51297206928d755b16142eceec7b809af55061e5"
+DOCKER_IMAGE_GO         += "golang:${GO_VERSION}@sha256:b17c35044f4062d83c815434615997eed97697daae8745c6dd39dc3673b87efb"
 DOCKER_IMAGE_GOLINT     += "golangci/golangci-lint:v1.50.1@sha256:94388e00f07c64262b138a7508f857473e30fdf0f59d04b546a305fc12cb5961"
 DOCKER_IMAGE_DOCKERLINT += "hadolint/hadolint:v2.9.2@sha256:d355bd7df747a0f124f3b5e7b21e9dafd0cb19732a276f901f0fdee243ec1f3b"
 DOCKER_IMAGE_COSIGN     += "bitnami/cosign:1.8.0@sha256:8c2c61c546258fffff18b47bb82a65af6142007306b737129a7bd5429d53629a"

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,7 @@
 # This dockerfile is used to build Mattermost calls-recorder
 # A multi stage build, with golang used as a builder
 # and ubuntu:22.04 as runner
-ARG GO_IMAGE=golang:1.18@sha256:fa71e1447cb0241324162a6c51297206928d755b16142eceec7b809af55061e5
+ARG GO_IMAGE=golang:1.21@sha256:b17c35044f4062d83c815434615997eed97697daae8745c6dd39dc3673b87efb
 ARG ARCH
 ARG RUNNER_IMAGE
 

--- a/cmd/recorder/cmd.go
+++ b/cmd/recorder/cmd.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"io"
-	"log"
+	"log/slog"
 	"os/exec"
 	"strings"
 )
@@ -12,7 +12,7 @@ const (
 )
 
 func runCmd(cmd string, args string) (*exec.Cmd, error) {
-	log.Printf("running %s: %q", cmd, args)
+	slog.Debug("running cmd", slog.String("cmd", cmd), slog.String("args", args))
 	c := exec.Command(cmd, strings.Split(args, " ")...)
 
 	stdout, err := c.StdoutPipe()
@@ -37,10 +37,17 @@ func runCmd(cmd string, args string) (*exec.Cmd, error) {
 				return
 			}
 			if err != nil {
-				log.Printf("%s (%s): error reading: %s", cmd, name, err)
+				slog.Debug("error reading log buffer",
+					slog.String("cmd", cmd),
+					slog.String("name", name),
+					slog.String("err", err.Error()),
+				)
 				return
 			}
-			log.Printf("%s (%s): %s", cmd, name, strings.TrimSuffix(string(buf[:n]), "\n"))
+			slog.Debug(strings.TrimSuffix(string(buf[:n]), "\n"),
+				slog.String("cmd", cmd),
+				slog.String("name", name),
+			)
 		}
 	}
 

--- a/cmd/recorder/main.go
+++ b/cmd/recorder/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
@@ -11,44 +11,56 @@ import (
 )
 
 func main() {
-	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		AddSource:   true,
+		Level:       slog.LevelDebug,
+		ReplaceAttr: slogReplaceAttr,
+	}))
+	slog.SetDefault(logger)
 
 	pid := os.Getpid()
 	if err := os.WriteFile("/tmp/recorder.pid", []byte(fmt.Sprintf("%d", pid)), 0666); err != nil {
-		log.Fatalf("failed to write pid file: %s", err)
+		slog.Error("failed to write pid file", slog.String("err", err.Error()))
+		os.Exit(1)
 	}
 
 	cfg, err := config.LoadFromEnv()
 	if err != nil {
-		log.Fatalf("failed to load config: %s", err)
+		slog.Error("failed to load config", slog.String("err", err.Error()))
+		os.Exit(1)
 	}
 	cfg.SetDefaults()
 
+	slog.SetDefault(logger.With("jobID", cfg.RecordingID))
+
 	recorder, err := NewRecorder(cfg)
 	if err != nil {
-		log.Fatalf("failed to create recorder: %s", err)
+		slog.Error("failed to create recorder", slog.String("err", err.Error()))
+		os.Exit(1)
 	}
 
-	log.Printf("starting recordinig")
+	slog.Info("starting recording")
 
 	if err := recorder.Start(); err != nil {
 		if err := recorder.ReportJobFailure(err.Error()); err != nil {
-			log.Printf("failed to report job failure: %s", err.Error())
+			slog.Error("failed to report job failure", slog.String("err", err.Error()))
 		}
-		log.Fatalf("failed to start recording: %s", err)
+		slog.Error("failed to start recording", slog.String("err", err.Error()))
+		os.Exit(1)
 	}
 
-	log.Printf("recording has started")
+	slog.Info("recording has started")
 
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	<-sig
 
-	log.Printf("received SIGTERM, stopping recording")
+	slog.Info("received SIGTERM, stopping recording")
 
 	if err := recorder.Stop(); err != nil {
-		log.Fatalf("failed to stop recording: %s", err)
+		slog.Error("failed to stop recording", slog.String("err", err.Error()))
+		os.Exit(1)
 	}
 
-	log.Printf("recording has finished, exiting")
+	slog.Info("recording has finished, exiting")
 }

--- a/cmd/recorder/recorder.go
+++ b/cmd/recorder/recorder.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -90,14 +90,14 @@ func (rec *Recorder) runBrowser(recURL string) error {
 	}
 
 	contextOpts := []chromedp.ContextOption{
-		chromedp.WithErrorf(log.Printf),
+		chromedp.WithErrorf(slogDebugF),
 	}
 	if devMode := os.Getenv("DEV_MODE"); devMode == "true" {
 		opts = append(opts, chromedp.Flag("unsafely-treat-insecure-origin-as-secure",
 			"http://172.17.0.1:8065,http://host.docker.internal:8065,http://mm-server:8065,http://host.minikube.internal:8065"))
 		opts = append(opts, chromedp.NoSandbox)
-		contextOpts = append(contextOpts, chromedp.WithLogf(log.Printf))
-		contextOpts = append(contextOpts, chromedp.WithDebugf(log.Printf))
+		contextOpts = append(contextOpts, chromedp.WithLogf(slogDebugF))
+		contextOpts = append(contextOpts, chromedp.WithDebugf(slogDebugF))
 	}
 
 	allocCtx, _ := chromedp.NewExecAllocator(context.Background(), opts...)
@@ -106,9 +106,9 @@ func (rec *Recorder) runBrowser(recURL string) error {
 	chromedp.ListenTarget(ctx, func(ev interface{}) {
 		switch ev := ev.(type) {
 		case *cruntime.EventExceptionThrown:
-			log.Printf("chrome exception: %s", ev.ExceptionDetails.Text)
+			slog.Error("chrome exception", slog.String("err", ev.ExceptionDetails.Text))
 			if ev.ExceptionDetails.Exception != nil {
-				log.Printf("chrome exception: %s", ev.ExceptionDetails.Exception.Description)
+				slog.Error("chrome exception", slog.String("err", ev.ExceptionDetails.Exception.Description))
 			}
 		case *cruntime.EventConsoleAPICalled:
 			args := make([]string, 0, len(ev.Args))
@@ -118,7 +118,7 @@ func (rec *Recorder) runBrowser(recURL string) error {
 				if len(arg.Value) > 0 {
 					err := json.Unmarshal(arg.Value, &val)
 					if err != nil {
-						log.Printf("failed to unmarshal: %s", err)
+						slog.Error("failed to unmarshal", slog.String("err", err.Error()))
 						continue
 					}
 					str = fmt.Sprintf("%+v", val)
@@ -130,7 +130,7 @@ func (rec *Recorder) runBrowser(recURL string) error {
 
 			str := fmt.Sprintf("chrome console %s %s", ev.Type.String(), strings.Join(args, " "))
 
-			log.Printf(sanitizeConsoleLog(str))
+			slog.Debug(sanitizeConsoleLog(str))
 		}
 	})
 
@@ -142,7 +142,7 @@ func (rec *Recorder) runBrowser(recURL string) error {
 		tctx, cancelCtx := context.WithTimeout(ctx, stopTimeout)
 		// graceful cancel
 		if err := chromedp.Cancel(tctx); err != nil {
-			log.Printf("failed to cancel context: %s", err)
+			slog.Error("failed to cancel context", slog.String("err", err.Error()))
 		}
 		cancelCtx()
 		close(rec.stoppedCh)
@@ -156,21 +156,21 @@ func (rec *Recorder) runBrowser(recURL string) error {
 	for {
 		select {
 		case <-rec.stopCh:
-			log.Printf("stop signal received, shutting down browser")
+			slog.Info("stop signal received, shutting down browser")
 			return nil
 		case <-ticker.C:
 			if err := chromedp.Run(ctx,
 				chromedp.Evaluate(connectCheckExpr, &connected),
 			); err != nil {
-				log.Printf("failed to run chromedp: %s", err)
+				slog.Error("failed to run chromedp", slog.String("err", err.Error()))
 				continue
 			}
 			if !connected {
-				log.Printf("not connected to call yet")
+				slog.Debug("not connected to call yet")
 				continue
 			}
 
-			log.Printf("connected to call")
+			slog.Debug("connected to call")
 			close(rec.readyCh)
 		}
 		break
@@ -181,17 +181,17 @@ func (rec *Recorder) runBrowser(recURL string) error {
 	for {
 		select {
 		case <-rec.stopCh:
-			log.Printf("stop signal received, shutting down browser")
+			slog.Info("stop signal received, shutting down browser")
 		case <-ticker.C:
 			if err := chromedp.Run(ctx,
 				chromedp.Evaluate(disconnectCheckExpr, &disconnected),
 			); err != nil {
-				log.Printf("failed to run chromedp: %s", err)
+				slog.Error("failed to run chromedp", slog.String("err", err.Error()))
 			}
 			if disconnected {
-				log.Printf("disconnected from call, shutting down")
+				slog.Info("disconnected from call, shutting down")
 				if err := syscall.Kill(syscall.Getpid(), syscall.SIGTERM); err != nil {
-					log.Printf("failed to send SIGTERM signal: %s", err)
+					slog.Error("failed to send SIGTERM signal", slog.String("err", err.Error()))
 				}
 				return nil
 			}
@@ -204,12 +204,12 @@ func (rec *Recorder) runBrowser(recURL string) error {
 	if err := chromedp.Run(ctx,
 		chromedp.Evaluate(disconnectExpr+disconnectCheckExpr, &disconnected),
 	); err != nil {
-		log.Printf("failed to run chromedp: %s", err)
+		slog.Error("failed to run chromedp", slog.String("err", err.Error()))
 	}
 	if disconnected {
-		log.Printf("disconnected from call successfully")
+		slog.Info("disconnected from call successfully")
 	} else {
-		log.Printf("failed to disconnect")
+		slog.Error("failed to disconnect")
 	}
 
 	return nil
@@ -229,7 +229,7 @@ func (rec *Recorder) runTranscoder(dst string) error {
 
 	cmd, err := runCmd("ffmpeg", args)
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("failed to run transcoder command: %w", err)
 	}
 
 	rec.transcoder = cmd
@@ -267,7 +267,7 @@ func (rec *Recorder) Start() error {
 		} else if strings.TrimSpace(string(data)) != "1" {
 			return fmt.Errorf("kernel.unprivileged_userns_clone should be enabled for the recording process to work")
 		}
-		log.Printf("kernel.unprivileged_userns_clone is correctly set")
+		slog.Debug("kernel.unprivileged_userns_clone is correctly set")
 	}
 
 	var err error
@@ -288,7 +288,7 @@ func (rec *Recorder) Start() error {
 
 	go func() {
 		if err := rec.runBrowser(recURL); err != nil {
-			log.Printf("failed to run browser: %s", err)
+			slog.Error("failed to run browser", slog.String("err", err.Error()))
 		}
 	}()
 
@@ -298,7 +298,7 @@ func (rec *Recorder) Start() error {
 		return fmt.Errorf("timed out waiting for ready event")
 	}
 
-	log.Printf("browser connected, ready to record")
+	slog.Info("browser connected, ready to record")
 
 	filename := fmt.Sprintf("%s-%s.mp4", rec.cfg.CallID, time.Now().UTC().Format("2006-01-02-15_04_05"))
 	rec.outPath = filepath.Join("/recs", filename)
@@ -316,10 +316,10 @@ func (rec *Recorder) Start() error {
 
 func (rec *Recorder) Stop() error {
 	if err := rec.transcoder.Process.Signal(syscall.SIGTERM); err != nil {
-		log.Printf("failed to send signal: %s", err.Error())
+		slog.Error("failed to send signal", slog.String("err", err.Error()))
 	}
 	if err := rec.transcoder.Wait(); err != nil {
-		log.Printf("failed waiting for transcoder to exit: %s", err)
+		slog.Error("failed waiting for transcoder to exit", slog.String("err", err.Error()))
 	}
 
 	close(rec.stopCh)
@@ -331,7 +331,7 @@ func (rec *Recorder) Stop() error {
 	}
 
 	if err := rec.displayServer.Process.Kill(); err != nil {
-		log.Printf("failed to stop display process: %s", err)
+		slog.Error("failed to stop display process", slog.String("err", err.Error()))
 	}
 
 	// TODO (MM-48546): implement better retry logic.
@@ -339,7 +339,7 @@ func (rec *Recorder) Stop() error {
 	for {
 		err := rec.uploadRecording()
 		if err == nil {
-			log.Printf("recording uploaded successfully")
+			slog.Info("recording uploaded successfully")
 			break
 		}
 
@@ -348,13 +348,13 @@ func (rec *Recorder) Stop() error {
 		}
 
 		attempt++
-		log.Printf("failed to upload recording: %s", err)
-		log.Printf("retrying in %s", uploadRetryAttemptWaitTime)
+		slog.Info("failed to upload recording", slog.String("err", err.Error()))
+		slog.Info("retrying", slog.Duration("wait_time", uploadRetryAttemptWaitTime))
 		time.Sleep(uploadRetryAttemptWaitTime)
 	}
 
 	if err := os.Remove(rec.outPath); err != nil {
-		log.Printf("failed to remove recording: %s", err)
+		slog.Error("failed to remove recording", slog.String("err", err.Error()))
 	}
 
 	return nil

--- a/cmd/recorder/utils.go
+++ b/cmd/recorder/utils.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+	"log/slog"
+	"path/filepath"
 	"regexp"
 )
 
@@ -10,4 +13,17 @@ var (
 
 func sanitizeConsoleLog(str string) string {
 	return icePasswordRE.ReplaceAllString(str, "ice-pwd:XXX")
+}
+
+func slogDebugF(format string, args ...any) {
+	slog.Debug(fmt.Sprintf(format, args...))
+}
+
+func slogReplaceAttr(_ []string, a slog.Attr) slog.Attr {
+	if a.Key == slog.SourceKey {
+		source := a.Value.Any().(*slog.Source)
+		source.File = filepath.Base(source.File)
+	}
+
+	return a
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattermost/calls-recorder
 
-go 1.18
+go 1.21.1
 
 require (
 	github.com/chromedp/cdproto v0.0.0-20230828023241-f357fd93b5d6


### PR DESCRIPTION
#### Summary

PR implements structured logging. This should make it much easier to filter through production logs and identify issues specific to a job run.

Sample output:

```
time=2023-10-04T20:18:51.604Z level=INFO source=main.go:42 msg="starting recording" jobID=gzcdxf5epbfjpbcaqd5h7etkfw
time=2023-10-04T20:18:51.605Z level=DEBUG source=recorder.go:270 msg="kernel.unprivileged_userns_clone is correctly set" jobID=gzcdxf5epbfjpbcaqd5h7etkfw
time=2023-10-04T20:18:51.605Z level=DEBUG source=cmd.go:15 msg="running cmd" jobID=gzcdxf5epbfjpbcaqd5h7etkfw cmd=Xvfb args=":45 -screen 0 1280x720x24 -dpi 96 -nolisten tcp -nolisten unix"
time=2023-10-04T20:18:55.189Z level=DEBUG source=recorder.go:169 msg="not connected to call yet" jobID=gzcdxf5epbfjpbcaqd5h7etkfw
time=2023-10-04T20:18:56.189Z level=DEBUG source=recorder.go:173 msg="connected to call" jobID=gzcdxf5epbfjpbcaqd5h7etkfw
time=2023-10-04T20:18:56.189Z level=INFO source=recorder.go:301 msg="browser connected, ready to record" jobID=gzcdxf5epbfjpbcaqd5h7etkfw
time=2023-10-04T20:18:56.189Z level=DEBUG source=cmd.go:15 msg="running cmd" jobID=gzcdxf5epbfjpbcaqd5h7etkfw cmd=ffmpeg args="-y -thread_queue_size 4096 -f alsa -i default -r 20 -thread_queue_size 4096 -f x11grab -draw_mouse 0 -s 1280x720 -i :45 -c:v h264 -preset veryfast -vf format=yuv420p -b:v 1500k -b:a 64k -movflags +faststart /recs/9tw5pykq838qmr7oa836binowc-2023-10-04-20_18_56.mp4"
```

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54747