### PR TITLE
Improve system requirements check

### DIFF
--- a/cmd/recorder/recorder.go
+++ b/cmd/recorder/recorder.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -260,14 +259,8 @@ func NewRecorder(cfg config.RecorderConfig) (*Recorder, error) {
 }
 
 func (rec *Recorder) Start() error {
-	// Verify that the required sysctl is set.
-	if runtime.GOOS == "linux" {
-		if data, err := os.ReadFile("/proc/sys/kernel/unprivileged_userns_clone"); err != nil {
-			return fmt.Errorf("failed to read sysctl: %w", err)
-		} else if strings.TrimSpace(string(data)) != "1" {
-			return fmt.Errorf("kernel.unprivileged_userns_clone should be enabled for the recording process to work")
-		}
-		slog.Debug("kernel.unprivileged_userns_clone is correctly set")
+	if err := checkOSRequirements(); err != nil {
+		return err
 	}
 
 	var err error

--- a/cmd/recorder/utils.go
+++ b/cmd/recorder/utils.go
@@ -3,12 +3,16 @@ package main
 import (
 	"fmt"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
+	"strings"
 )
 
 var (
-	icePasswordRE = regexp.MustCompile(`ice-pwd:[\w|\+|/]+`)
+	unpriviledgeUsersCloneSysctlPath = "/proc/sys/kernel/unprivileged_userns_clone"
+	icePasswordRE                    = regexp.MustCompile(`ice-pwd:[\w|\+|/]+`)
 )
 
 func sanitizeConsoleLog(str string) string {
@@ -26,4 +30,19 @@ func slogReplaceAttr(_ []string, a slog.Attr) slog.Attr {
 	}
 
 	return a
+}
+
+func checkOSRequirements() error {
+	// Verify that the required sysctl is set.
+	if runtime.GOOS == "linux" {
+		if data, err := os.ReadFile(unpriviledgeUsersCloneSysctlPath); err != nil {
+			slog.Warn("failed to read sysctl", slog.String("err", err.Error()))
+		} else if strings.TrimSpace(string(data)) != "1" {
+			return fmt.Errorf("kernel.unprivileged_userns_clone should be enabled for the recording process to work")
+		} else {
+			slog.Debug("kernel.unprivileged_userns_clone is correctly set")
+		}
+	}
+
+	return nil
 }

--- a/cmd/recorder/utils_test.go
+++ b/cmd/recorder/utils_test.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"bytes"
+	"log/slog"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -37,4 +41,59 @@ func TestSanitizeConsoleLog(t *testing.T) {
 			require.Equal(t, tc.expected, sanitizeConsoleLog(tc.input))
 		})
 	}
+}
+
+func TestCheckOSRequirements(t *testing.T) {
+	var logBuf bytes.Buffer
+
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+		ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.TimeKey {
+				a.Value = slog.StringValue("")
+			}
+			return a
+		},
+	}))
+
+	defLogger := slog.Default()
+	slog.SetDefault(logger)
+	defer slog.SetDefault(defLogger)
+
+	defer func(path string) {
+		unpriviledgeUsersCloneSysctlPath = path
+	}(unpriviledgeUsersCloneSysctlPath)
+
+	f, err := os.CreateTemp("", "unprivileged_userns_clone")
+	require.NoError(t, err)
+	defer f.Close()
+	defer os.Remove(f.Name())
+	unpriviledgeUsersCloneSysctlPath = f.Name()
+
+	t.Run("on", func(t *testing.T) {
+		_, err := f.Write([]byte("1"))
+		require.NoError(t, err)
+		err = checkOSRequirements()
+		require.NoError(t, err)
+		require.Equal(t, `time="" level=DEBUG msg="kernel.unprivileged_userns_clone is correctly set"`, strings.TrimSpace(logBuf.String()))
+	})
+
+	t.Run("off", func(t *testing.T) {
+		_, err := f.Seek(0, 0)
+		require.NoError(t, err)
+
+		_, err = f.Write([]byte("0"))
+		require.NoError(t, err)
+
+		err = checkOSRequirements()
+		require.EqualError(t, err, "kernel.unprivileged_userns_clone should be enabled for the recording process to work")
+	})
+
+	t.Run("missing", func(t *testing.T) {
+		unpriviledgeUsersCloneSysctlPath = "/tmp/invalid"
+		logBuf.Reset()
+		err = checkOSRequirements()
+		require.NoError(t, err)
+		require.Equal(t, `time="" level=WARN msg="failed to read sysctl" err="open /tmp/invalid: no such file or directory"`, strings.TrimSpace(logBuf.String()))
+	})
 }


### PR DESCRIPTION
#### Summary

Looks like there are still some Linux environments (e.g. in our e2e test setup) with the sysctl missing. In such cases we log a warning but otherwise proceed.