### PR TITLE
[MM-55259] Return success exit code on failure to start to allow for resources cleanup

### DIFF
--- a/build/pkgs_list
+++ b/build/pkgs_list
@@ -1,8 +1,8 @@
 ca-certificates=20230311
-chromium=119.0.6045.159-1
-chromium-driver=119.0.6045.159-1
-chromium-sandbox=119.0.6045.159-1
-ffmpeg=7:6.1-4
+chromium=119.0.6045.199-1
+chromium-driver=119.0.6045.199-1
+chromium-sandbox=119.0.6045.199-1
+ffmpeg=7:6.1-5
 fonts-recommended=1
 pulseaudio=16.1+dfsg1-2+b1
 wget=1.21.4-1+b1

--- a/cmd/recorder/main.go
+++ b/cmd/recorder/main.go
@@ -52,7 +52,11 @@ func main() {
 			slog.Error("failed to stop recorder", slog.String("err", err.Error()))
 		}
 
-		os.Exit(1)
+		// Although an error case, if we fail to start we are not losing any
+		// recording data so the associated resources (e.g. container, volume) can be safely deleted.
+		// This is signaled to the calling layer (calls-offloader) by exiting with
+		// a success code.
+		os.Exit(0)
 	}
 
 	slog.Info("recording has started")


### PR DESCRIPTION
#### Summary

From the `calls-offloader` side we automatically delete successful jobs but retain failed ones to prevent data loss. However, there are instances in which we can guarantee there's no data loss even in case of failure. The most common example is a recording job that is stopped during initialization, before it gets to record anything. This is happening quite frequently on Community and it's generating alerts that require manual intervention (checking logs and manually delete these jobs).

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-55259
