### PR TITLE
Increase publish retry attempts

### DIFF
--- a/build/pkgs_list
+++ b/build/pkgs_list
@@ -1,9 +1,9 @@
 ca-certificates=20230311
-chromium=120.0.6099.71-1
-chromium-driver=120.0.6099.71-1
-chromium-sandbox=120.0.6099.71-1
-ffmpeg=7:6.1-5
+chromium=120.0.6099.216-1
+chromium-driver=120.0.6099.216-1
+chromium-sandbox=120.0.6099.216-1
+ffmpeg=7:6.1.1-1
 fonts-recommended=1
-pulseaudio=16.1+dfsg1-2+b1
+pulseaudio=16.1+dfsg1-3
 wget=1.21.4-1+b1
-xvfb=2:21.1.9-1
+xvfb=2:21.1.10-1

--- a/cmd/recorder/upload_test.go
+++ b/cmd/recorder/upload_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/mattermost/calls-recorder/cmd/recorder/config"
 
@@ -132,6 +134,121 @@ func TestUploadRecording(t *testing.T) {
 			return false
 		})
 		err := rec.uploadRecording()
+		require.NoError(t, err)
+	})
+}
+
+func TestPublishRecording(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		AddSource: true,
+		Level:     slog.LevelDebug,
+	}))
+	slog.SetDefault(logger)
+
+	middlewares := []middleware{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for _, mw := range middlewares {
+			if mw(w, r) {
+				return
+			}
+		}
+		http.NotFound(w, r)
+	}))
+	defer ts.Close()
+
+	cfg := config.RecorderConfig{
+		SiteURL:     ts.URL,
+		CallID:      "8w8jorhr7j83uqr6y1st894hqe",
+		PostID:      "udzdsg7dwidbzcidx5khrf8nee",
+		RecordingID: "67t5u6cmtfbb7jug739d43xa9e",
+		AuthToken:   "qj75unbsef83ik9p7ueypb6iyw",
+	}
+	cfg.SetDefaults()
+	rec, err := NewRecorder(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+
+	recFile, err := os.CreateTemp("", "recording.mp4")
+	require.NoError(t, err)
+	defer os.Remove(recFile.Name())
+
+	rec.outPath = recFile.Name()
+
+	uploadRetryAttemptWaitTime = time.Second
+
+	t.Run("success after multiple failed attempts", func(t *testing.T) {
+		var failures int
+		middlewares = []middleware{
+			func(w http.ResponseWriter, r *http.Request) bool {
+				if r.URL.Path == "/plugins/com.mattermost.calls/bot/uploads" && r.Method == http.MethodPost {
+					fmt.Fprintln(w, `{"id": "uploadID"}`)
+					return true
+				}
+
+				return false
+			},
+			func(w http.ResponseWriter, r *http.Request) bool {
+				if r.URL.Path == "/plugins/com.mattermost.calls/bot/uploads/uploadID" && r.Method == http.MethodPost {
+					fmt.Fprintln(w, `{"id": "fileID"}`)
+					return true
+				}
+
+				return false
+			},
+			func(w http.ResponseWriter, r *http.Request) bool {
+				if r.URL.Path == "/plugins/com.mattermost.calls/bot/calls/8w8jorhr7j83uqr6y1st894hqe/recordings" && r.Method == http.MethodPost {
+					if failures < 5 {
+						w.WriteHeader(400)
+						fmt.Fprintln(w, `{"message": "server error"}`)
+						failures++
+					} else {
+						w.WriteHeader(200)
+					}
+					return true
+				}
+				return false
+			},
+		}
+
+		err := rec.publishRecording()
+		require.NoError(t, err)
+	})
+
+	t.Run("failure after maximum attempts reached", func(t *testing.T) {
+		uploadRetryAttemptWaitTime = 10 * time.Millisecond
+
+		middlewares[1] = func(w http.ResponseWriter, r *http.Request) bool {
+			if r.URL.Path == "/plugins/com.mattermost.calls/bot/uploads/uploadID" && r.Method == http.MethodPost {
+				w.WriteHeader(500)
+				fmt.Fprintln(w, `{"message": "server error"}`)
+				return true
+			}
+
+			return false
+		}
+
+		err := rec.publishRecording()
+		require.EqualError(t, err, "max retry attempts reached, exiting")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		middlewares[1] = func(w http.ResponseWriter, r *http.Request) bool {
+			if r.URL.Path == "/plugins/com.mattermost.calls/bot/uploads/uploadID" && r.Method == http.MethodPost {
+				fmt.Fprintln(w, `{"id": "fileID"}`)
+				return true
+			}
+			return false
+		}
+
+		middlewares[2] = func(w http.ResponseWriter, r *http.Request) bool {
+			if r.URL.Path == "/plugins/com.mattermost.calls/bot/calls/8w8jorhr7j83uqr6y1st894hqe/recordings" && r.Method == http.MethodPost {
+				w.WriteHeader(200)
+				return true
+			}
+			return false
+		}
+
+		err := rec.publishRecording()
 		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
#### Summary

PR increase the re-try attempts to publish a recording. This will also give us more time to manually retrieve the recording in case of failure. While this is not a long term issue to address data loss (see https://mattermost.atlassian.net/browse/MM-56524 and related discussion), it's a quick fix that can prevent some of it in the future.

