### PR TITLE
Implement custom transport to incercept and log HTTP errors

### DIFF
--- a/cmd/recorder/recorder.go
+++ b/cmd/recorder/recorder.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -323,6 +324,11 @@ func NewRecorder(cfg config.RecorderConfig) (*Recorder, error) {
 
 	client := model.NewAPIv4Client(cfg.SiteURL)
 	client.SetToken(cfg.AuthToken)
+	client.HTTPClient = &http.Client{
+		Transport: &clientTransport{
+			transport: http.DefaultTransport,
+		},
+	}
 
 	return &Recorder{
 		cfg:                 cfg,

--- a/cmd/recorder/upload_test.go
+++ b/cmd/recorder/upload_test.go
@@ -52,6 +52,22 @@ func TestUploadRecording(t *testing.T) {
 
 	rec.outPath = recFile.Name()
 
+	t.Run("invalid response", func(t *testing.T) {
+		middlewares = []middleware{
+			func(w http.ResponseWriter, r *http.Request) bool {
+				if r.URL.Path == "/plugins/com.mattermost.calls/bot/uploads" && r.Method == http.MethodPost {
+					w.WriteHeader(500)
+					fmt.Fprintln(w, `Internal Server Error`)
+					return true
+				}
+
+				return false
+			},
+		}
+		err := rec.uploadRecording()
+		require.EqualError(t, err, "failed to create upload: AppErrorFromJSON: model.utils.decode_json.app_error, body: Internal Server Error\n, invalid character 'I' looking for beginning of value")
+	})
+
 	t.Run("upload creation failure", func(t *testing.T) {
 		middlewares = []middleware{
 			func(w http.ResponseWriter, r *http.Request) bool {


### PR DESCRIPTION
#### Summary

We implement a custom `http.RoundTripper` so we can intercept and properly log HTTP errors that would otherwise be parsed as JSON causing failure to log anything meaningful, e.g.:

```
failed to create upload: AppErrorFromJSON: model.utils.decode_json.app_error, body: Internal Server Error\n, invalid character 'I' looking for beginning of value
```

Now we'd be logging this:

```
2024/01/24 16:02:07 ERROR request failed with failure status code code=500 url=http://127.0.0.1:41085/plugins/com.mattermost.calls/bot/uploads method=POST data="Internal Server Error\n"
```

