### PR TITLE
Add security exception to SiteURL setting to allow connecting from within local networks

### DIFF
--- a/build/pkgs_list
+++ b/build/pkgs_list
@@ -1,7 +1,7 @@
-ca-certificates=20230311
-chromium=121.0.6167.85-1
-chromium-driver=121.0.6167.85-1
-chromium-sandbox=121.0.6167.85-1
+ca-certificates=20240203
+chromium=121.0.6167.160-1
+chromium-driver=121.0.6167.160-1
+chromium-sandbox=121.0.6167.160-1
 ffmpeg=7:6.1.1-1
 fonts-recommended=1
 pulseaudio=16.1+dfsg1-3

--- a/cmd/recorder/recorder.go
+++ b/cmd/recorder/recorder.go
@@ -65,56 +65,9 @@ type Recorder struct {
 }
 
 func (rec *Recorder) runBrowser(recURL string) (rerr error) {
-	opts := []chromedp.ExecAllocatorOption{
-		chromedp.NoFirstRun,
-		chromedp.NoDefaultBrowserCheck,
-		chromedp.DisableGPU,
-
-		// puppeteer default behavior
-		chromedp.Flag("disable-infobars", true),
-		chromedp.Flag("disable-background-networking", true),
-		chromedp.Flag("enable-features", "NetworkService,NetworkServiceInProcess"),
-		chromedp.Flag("disable-background-timer-throttling", true),
-		chromedp.Flag("disable-backgrounding-occluded-windows", true),
-		chromedp.Flag("disable-breakpad", true),
-		chromedp.Flag("disable-client-side-phishing-detection", true),
-		chromedp.Flag("disable-default-apps", true),
-		chromedp.Flag("disable-dev-shm-usage", true),
-		chromedp.Flag("disable-extensions", true),
-		chromedp.Flag("disable-features", "site-per-process,TranslateUI,BlinkGenPropertyTrees"),
-		chromedp.Flag("disable-hang-monitor", true),
-		chromedp.Flag("disable-ipc-flooding-protection", true),
-		chromedp.Flag("disable-popup-blocking", true),
-		chromedp.Flag("disable-prompt-on-repost", true),
-		chromedp.Flag("disable-renderer-backgrounding", true),
-		chromedp.Flag("disable-sync", true),
-		chromedp.Flag("force-color-profile", "srgb"),
-		chromedp.Flag("metrics-recording-only", true),
-		chromedp.Flag("safebrowsing-disable-auto-update", true),
-		chromedp.Flag("password-store", "basic"),
-		chromedp.Flag("use-mock-keychain", true),
-		chromedp.Flag("use-fake-ui-for-media-stream", true),
-		chromedp.Flag("use-fake-device-for-media-stream", true),
-
-		// custom args
-		chromedp.Flag("incognito", true),
-		chromedp.Flag("kiosk", true),
-		chromedp.Flag("enable-automation", false),
-		chromedp.Flag("autoplay-policy", "no-user-gesture-required"),
-		chromedp.Flag("window-position", "0,0"),
-		chromedp.Flag("window-size", fmt.Sprintf("%d,%d", rec.cfg.Width, rec.cfg.Height)),
-		chromedp.Flag("display", fmt.Sprintf(":%d", displayID)),
-	}
-
-	contextOpts := []chromedp.ContextOption{
-		chromedp.WithErrorf(slogDebugF),
-	}
-	if devMode := os.Getenv("DEV_MODE"); devMode == "true" {
-		opts = append(opts, chromedp.Flag("unsafely-treat-insecure-origin-as-secure",
-			"http://172.17.0.1:8065,http://host.docker.internal:8065,http://mm-server:8065,http://host.minikube.internal:8065"))
-		opts = append(opts, chromedp.NoSandbox)
-		contextOpts = append(contextOpts, chromedp.WithLogf(slogDebugF))
-		contextOpts = append(contextOpts, chromedp.WithDebugf(slogDebugF))
+	opts, contextOpts, err := genChromiumOptions(rec.cfg)
+	if err != nil {
+		return fmt.Errorf("failed to generate Chromium options: %w", err)
 	}
 
 	allocCtx, _ := chromedp.NewExecAllocator(context.Background(), opts...)


### PR DESCRIPTION
#### Summary

There's a fair bit of context in the huge thread at https://hub.mattermost.com/private-core/pl/byryfi96nj88fxh78priet8cto. Trying to quickly summarize here:

As of late we have been seeing some recurring issues with calls recordings that randomly (but consistently) fail to get uploaded. It's still unclear at which level these requests are failing but what's clear is that the networking flow is fairly complex as the client needs to go through several hops (Cloudflare -> Nginx -> K8S service -> MM pod). 

This PR tries to simplify the above by allowing the recorder client to connect from within an internal (private) network. To do so, we add an exception to allow connectivity from the given SiteURL in case this is plain text HTTP. This is achieved by adding the URL to the list passed through the `--unsafely-treat-insecure-origin-as-secure` Chromium flag.

This is necessary since Calls has a strict requirement for HTTPs in order to allow clients to connect. And this is imposed by the Chromium implementation which requires a secure context in order to expose certain browser APIs we rely on. 

Given the nature of the changes I am pinging a couple of security people here as I'd like everyone to understand and (hopefully agree) on what's being proposed.

/cc @andrleite @stylianosrigas for visibility on the SREs side

#### Related PR

https://github.com/mattermost/mattermost-plugin-calls/pull/640

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-56920
