### PR TITLE
[MM-48545] Implement resumable upload logic

### DIFF
--- a/build/pkgs_list
+++ b/build/pkgs_list
@@ -1,7 +1,7 @@
-ca-certificates=20230311
-chromium=121.0.6167.85-1
-chromium-driver=121.0.6167.85-1
-chromium-sandbox=121.0.6167.85-1
+ca-certificates=20240203
+chromium=121.0.6167.160-1
+chromium-driver=121.0.6167.160-1
+chromium-sandbox=121.0.6167.160-1
 ffmpeg=7:6.1.1-1
 fonts-recommended=1
 pulseaudio=16.1+dfsg1-3


### PR DESCRIPTION
#### Summary

PR add resumable upload logic to the `uploadRecording` method. This is particularly helpful in case the MM server has a lower `FileSettings.MaxFileSize` than the recording file size in which case the file is uploaded in chunks, essentially overcoming the config limitation.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-48545
