### PR TITLE
[MM-60187] Update Golang to v1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,21 +9,18 @@ jobs:
       run:
         working-directory: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
 
-    strategy:
-      matrix:
-        go-version: [1.21.x]
-
     runs-on: ubuntu-latest
 
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go-version }}
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         path: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}/go.mod
+        cache-dependency-path: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}/go.sum
     - name: Execute Tests
       run: |
         go mod download

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -5,21 +5,15 @@ permissions:
 jobs:
   golangci:
     name: lint
-    strategy:
-      matrix:
-        go-version: [1.21.x]
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go-version }}
       - name: Checkout Code
-        uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v5
         with:
-          version: v1.54.2
-
-          # Optional: if set to true then the action will use pre-installed Go.
-          skip-go-installation: true
+          go-version-file: go.mod
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.61.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,7 +42,7 @@ linters:
     - ineffassign   # Detects when assignments to existing variables are not used
     - unconvert     # Removes unnecessary type conversions
     - unused        # Checks Go code for unused constants, variables, functions and types
-    - exportloopref # Checks for pointers to enclosing loop variables
+    - copyloopvar   # Checks for pointers to enclosing loop variables
     - errcheck      # Detects unchecked errors.
 
 issues:

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ DOCKER_USER             ?= user
 DOCKER_PASSWORD         ?= password
 # Docker Images
 DOCKER_IMAGE_GO         += "golang:${GO_VERSION}"
-DOCKER_IMAGE_GOLINT     += "golangci/golangci-lint:v1.54.2@sha256:abe731fe6bb335a30eab303a41dd5c2b630bb174372a4da08e3d42eab5324127"
+DOCKER_IMAGE_GOLINT     += "golangci/golangci-lint:v1.60.0@sha256:e47065d755ca0afeac9df866d1dabdc99f439653a43fe234e05f50d9c36b6b90"
 DOCKER_IMAGE_DOCKERLINT += "hadolint/hadolint:v2.12.0@sha256:9259e253a4e299b50c92006149dd3a171c7ea3c5bd36f060022b5d2c1ff0fbbe"
 DOCKER_IMAGE_COSIGN     += "bitnami/cosign:1.8.0@sha256:8c2c61c546258fffff18b47bb82a65af6142007306b737129a7bd5429d53629a"
 DOCKER_IMAGE_GH_CLI     += "ghcr.io/supportpal/github-gh-cli:2.31.0@sha256:71371e36e62bd24ddd42d9e4c720a7e9954cb599475e24d1407af7190e2a5685"

--- a/build/pkgs_list_amd64
+++ b/build/pkgs_list_amd64
@@ -1,7 +1,7 @@
 ca-certificates=20240203
-chromium=128.0.6613.137-1
-chromium-driver=128.0.6613.137-1
-chromium-sandbox=128.0.6613.137-1
+chromium=129.0.6668.58-1
+chromium-driver=129.0.6668.58-1
+chromium-sandbox=129.0.6668.58-1
 ffmpeg=7:7.0.2-3
 fonts-recommended=1
 pulseaudio=16.1+dfsg1-5.1

--- a/build/pkgs_list_arm64
+++ b/build/pkgs_list_arm64
@@ -1,7 +1,7 @@
 ca-certificates=20240203
-chromium=128.0.6613.137-1
-chromium-driver=128.0.6613.137-1
-chromium-sandbox=128.0.6613.137-1
+chromium=129.0.6668.58-1
+chromium-driver=129.0.6668.58-1
+chromium-sandbox=129.0.6668.58-1
 ffmpeg=7:7.0.2-3
 fonts-recommended=1
 pulseaudio=16.1+dfsg1-5.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattermost/calls-recorder
 
-go 1.21.4
+go 1.22.7
 
 require (
 	github.com/chromedp/cdproto v0.0.0-20230828023241-f357fd93b5d6


### PR DESCRIPTION
#### Summary

Updating Golang runtime to v1.22. Also taking the chance to update the linter and the CI actions.
#### Ticket Link

https://mattermost.atlassian.net/browse/MM-60187

