### PR TITLE
[MM-62338] Persist logs to scoped data path

### DIFF
--- a/build/pkgs_list_amd64
+++ b/build/pkgs_list_amd64
@@ -1,9 +1,9 @@
 ca-certificates=20240203
-chromium=130.0.6723.91-2
-chromium-driver=130.0.6723.91-2
-chromium-sandbox=130.0.6723.91-2
+chromium=131.0.6778.204-1
+chromium-driver=131.0.6778.204-1
+chromium-sandbox=131.0.6778.204-1
 ffmpeg=7:7.1-3
 fonts-recommended=1
-pulseaudio=16.1+dfsg1-5.1+b1
+pulseaudio=17.0+dfsg1-1
 wget=1.24.5-2+b1
-xvfb=2:21.1.14-1
+xvfb=2:21.1.15-2

--- a/build/pkgs_list_arm64
+++ b/build/pkgs_list_arm64
@@ -1,9 +1,9 @@
 ca-certificates=20240203
-chromium=130.0.6723.91-2
-chromium-driver=130.0.6723.91-2
-chromium-sandbox=130.0.6723.91-2
+chromium=131.0.6778.139-1
+chromium-driver=131.0.6778.139-1
+chromium-sandbox=131.0.6778.139-1
 ffmpeg=7:7.1-3
 fonts-recommended=1
-pulseaudio=16.1+dfsg1-5.1+b1
+pulseaudio=17.0+dfsg1-1
 wget=1.24.5-2
-xvfb=2:21.1.14-1
+xvfb=2:21.1.15-1

--- a/cmd/recorder/job_test.go
+++ b/cmd/recorder/job_test.go
@@ -34,7 +34,7 @@ func TestReportJobFailure(t *testing.T) {
 		AuthToken:   "qj75unbsef83ik9p7ueypb6iyw",
 	}
 	cfg.SetDefaults()
-	rec, err := NewRecorder(cfg)
+	rec, err := NewRecorder(cfg, getDataDir(""))
 	require.NoError(t, err)
 	require.NotNil(t, rec)
 

--- a/cmd/recorder/recorder_test.go
+++ b/cmd/recorder/recorder_test.go
@@ -10,8 +10,23 @@ import (
 
 func TestNewRecorder(t *testing.T) {
 	t.Run("invalid config", func(t *testing.T) {
-		rec, err := NewRecorder(config.RecorderConfig{})
+		rec, err := NewRecorder(config.RecorderConfig{}, getDataDir(""))
 		require.EqualError(t, err, "invalid config: config cannot be empty")
+		require.Nil(t, rec)
+	})
+
+	t.Run("invalid data path", func(t *testing.T) {
+		cfg := config.RecorderConfig{
+			SiteURL:     "http://localhost:8065",
+			CallID:      "8w8jorhr7j83uqr6y1st894hqe",
+			PostID:      "udzdsg7dwidbzcidx5khrf8nee",
+			RecordingID: "67t5u6cmtfbb7jug739d43xa9e",
+			AuthToken:   "qj75unbsef83ik9p7ueypb6iyw",
+		}
+		cfg.SetDefaults()
+
+		rec, err := NewRecorder(cfg, "")
+		require.EqualError(t, err, "data path cannot be empty")
 		require.Nil(t, rec)
 	})
 
@@ -24,7 +39,7 @@ func TestNewRecorder(t *testing.T) {
 			AuthToken:   "qj75unbsef83ik9p7ueypb6iyw",
 		}
 		cfg.SetDefaults()
-		rec, err := NewRecorder(cfg)
+		rec, err := NewRecorder(cfg, getDataDir(""))
 		require.NoError(t, err)
 		require.NotNil(t, rec)
 	})

--- a/cmd/recorder/upload_test.go
+++ b/cmd/recorder/upload_test.go
@@ -38,7 +38,7 @@ func TestUploadRecording(t *testing.T) {
 		AuthToken:   "qj75unbsef83ik9p7ueypb6iyw",
 	}
 	cfg.SetDefaults()
-	rec, err := NewRecorder(cfg)
+	rec, err := NewRecorder(cfg, getDataDir(""))
 	require.NoError(t, err)
 	require.NotNil(t, rec)
 
@@ -237,7 +237,7 @@ func TestPublishRecording(t *testing.T) {
 		AuthToken:   "qj75unbsef83ik9p7ueypb6iyw",
 	}
 	cfg.SetDefaults()
-	rec, err := NewRecorder(cfg)
+	rec, err := NewRecorder(cfg, getDataDir(""))
 	require.NoError(t, err)
 	require.NotNil(t, rec)
 

--- a/cmd/recorder/utils.go
+++ b/cmd/recorder/utils.go
@@ -91,11 +91,11 @@ func pollBrowserEvaluateExpr(ctx context.Context, expr string, interval, timeout
 	}
 }
 
-func getDataDir() string {
+func getDataDir(jobID string) string {
 	if dir := os.Getenv("DATA_DIR"); dir != "" {
-		return dir
+		return filepath.Join(dir, jobID)
 	}
-	return dataDir
+	return filepath.Join(dataDir, jobID)
 }
 
 func sanitizeFilename(name string) string {


### PR DESCRIPTION
#### Summary

Two changes here:

- We persist logs to the data path so they can be recovered in case of failure.
- We scope the data path by job ID so that if the underlying storage is shared, we don't get into conflict issues and keep everything nicely tied.


#### Ticket Link

https://mattermost.atlassian.net/browse/MM-62338
