### PR TITLE
[MM-63296] Bump Golang version to v1.23.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattermost/calls-recorder
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/chromedp/cdproto v0.0.0-20240202021202-6d0b6a386732


### PR DESCRIPTION
#### Summary

Bumping the Golang version used to build. 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-63296
