### PR TITLE
[MM-64555] Set permissions on job-scoped path

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -24,7 +24,7 @@ RUN set -ex && \
 RUN groupadd -r calls && useradd -mr -g calls -G audio,video,pulse-access calls
 
 ARG GO_VERSION
-FROM --platform=$BUILDPLATFORM golang:${GO_VERSION} as builder
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION} AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -22,7 +22,7 @@ exit_handler() {
     exit 1
   fi
 
-  EXIT_CODE=`cat $RECORDER_EXIT_CODE_FILE`
+  EXIT_CODE=$(cat $RECORDER_EXIT_CODE_FILE)
 
   exit $EXIT_CODE
 }
@@ -40,7 +40,7 @@ term_handler() {
     exit 1
   fi
 
-  RECORDER_PID=`cat $RECORDER_PID_FILE`
+  RECORDER_PID=$(cat $RECORDER_PID_FILE)
 
   # Relaying the SIGTERM to the recorder's process.
   kill -SIGTERM "$RECORDER_PID"
@@ -58,8 +58,10 @@ trap 'kill ${!}; term_handler' SIGTERM
 
 RECORDER_USER=calls
 
+# Create scoped (by jobID) data path.
+mkdir -p /data/$RECORDING_ID
 # Give permission to write recording files.
-chown -R $RECORDER_USER:$RECORDER_USER /data
+chown -R $RECORDER_USER:$RECORDER_USER /data/$RECORDING_ID
 # Give permissions to home directory so that Chromium can create any
 # necessary files and directories.
 chown -R $RECORDER_USER:$RECORDER_USER /home/$RECORDER_USER

--- a/build/pkgs_list_amd64
+++ b/build/pkgs_list_amd64
@@ -1,7 +1,7 @@
 ca-certificates=20250419
-chromium=136.0.7103.113-1
-chromium-driver=136.0.7103.113-1
-chromium-sandbox=136.0.7103.113-1
+chromium=137.0.7151.68-1
+chromium-driver=137.0.7151.68-1
+chromium-sandbox=137.0.7151.68-1
 ffmpeg=7:7.1.1-1+b1
 fonts-recommended=2
 pulseaudio=17.0+dfsg1-2+b1

--- a/build/pkgs_list_arm64
+++ b/build/pkgs_list_arm64
@@ -1,7 +1,7 @@
 ca-certificates=20250419
-chromium=136.0.7103.113-1
-chromium-driver=136.0.7103.113-1
-chromium-sandbox=136.0.7103.113-1
+chromium=137.0.7151.68-1
+chromium-driver=137.0.7151.68-1
+chromium-sandbox=137.0.7151.68-1
 ffmpeg=7:7.1.1-1+b1
 fonts-recommended=2
 pulseaudio=17.0+dfsg1-2+b1

--- a/cmd/recorder/main.go
+++ b/cmd/recorder/main.go
@@ -15,13 +15,7 @@ import (
 func main() {
 	recID := os.Getenv("RECORDING_ID")
 
-	// Create scoped (by jobID) data path
 	dataPath := getDataDir(recID)
-	err := os.MkdirAll(dataPath, 0700)
-	if err != nil {
-		slog.Error("failed to create data path", slog.String("err", err.Error()))
-		os.Exit(1)
-	}
 
 	logFile, err := os.Create(filepath.Join(dataPath, "recorder.log"))
 	if err != nil {


### PR DESCRIPTION
#### Summary

When running on a shared `/data` volume, recording and transcribing jobs could race to set permissions on `/data`. This is problematic because the system user/group IDs do not match (996 vs 999). To avoid this issue altogether, we set the permissions on the job-scoped path, namely `/data/JOB_ID`.

Also updating dependencies to prepare a new release.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-64555

