### PR TITLE
Bump dependencies for Calls 1.10

### DIFF
--- a/build/pkgs_list_amd64
+++ b/build/pkgs_list_amd64
@@ -1,9 +1,9 @@
 ca-certificates=20250419
-chromium=137.0.7151.103-1
-chromium-driver=137.0.7151.103-1
-chromium-sandbox=137.0.7151.103-1
+chromium=138.0.7204.92-1
+chromium-driver=138.0.7204.92-1
+chromium-sandbox=138.0.7204.92-1
 ffmpeg=7:7.1.1-1+b1
 fonts-recommended=2
 pulseaudio=17.0+dfsg1-2+b1
 wget=1.25.0-2
-xvfb=2:21.1.16-1.1
+xvfb=2:21.1.16-1.3

--- a/build/pkgs_list_arm64
+++ b/build/pkgs_list_arm64
@@ -1,9 +1,9 @@
 ca-certificates=20250419
-chromium=137.0.7151.103-1
-chromium-driver=137.0.7151.103-1
-chromium-sandbox=137.0.7151.103-1
+chromium=138.0.7204.92-1
+chromium-driver=138.0.7204.92-1
+chromium-sandbox=138.0.7204.92-1
 ffmpeg=7:7.1.1-1+b1
 fonts-recommended=2
 pulseaudio=17.0+dfsg1-2+b1
 wget=1.25.0-2
-xvfb=2:21.1.16-1.1
+xvfb=2:21.1.16-1.3


### PR DESCRIPTION
#### Summary
- bump dependencies for Calls 1.10

#### Ticket Link
- none

