### PR TITLE
Install dbus-x11 first to avoid systemd

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,14 +11,14 @@ ARG TARGETARCH
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY ./build/pkgs_list* .
-# Prevent dpkg from running service post-install scripts during build.
-# This avoids QEMU SIGSEGV when cross-building arm64 (systemd's post-install
-# script crashes under QEMU user-mode emulation).
-RUN printf '#!/bin/sh\nexit 101\n' > /usr/sbin/policy-rc.d && chmod +x /usr/sbin/policy-rc.d
-
+# Install dbus-x11 first to satisfy the dbus-session-bus virtual package
+# dependency (needed by dconf-service). This prevents apt from pulling in
+# dbus-user-session -> libpam-systemd -> systemd, whose postinst crashes
+# under QEMU user-mode emulation when cross-building arm64.
 # hadolint ignore=DL3008,SC2046
 RUN set -ex && \
     apt-get update && \
+    apt-get install --no-install-recommends -y dbus-x11 && \
     apt-get install --no-install-recommends -y $(cat pkgs_list_${TARGETARCH}) && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \


### PR DESCRIPTION
#### Summary
Install dbus-x11 first to satisfy the dbus-session-bus virtual package dependency (needed by dconf-service, needed by pulseaudio). This prevents apt from pulling in dbus-user-session -> libpam-systemd -> systemd, whose postinst crashes under QEMU user-mode emulation when cross-building arm64.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68167


